### PR TITLE
147: Fix file download stats

### DIFF
--- a/components/pages/environmental/DownloadModal/index.tsx
+++ b/components/pages/environmental/DownloadModal/index.tsx
@@ -35,6 +35,7 @@ import { fetchReleaseData } from '#global/hooks/useReleaseData/environmental';
 
 import { MetadataFileSection } from './MetadataFile';
 import { plainTextSequencingFileInstructions, SequencingFilesSection } from './SequencingFiles';
+import type { SQONType } from '@overture-stack/arranger-components';
 
 /**
  * Advisory section to display the data usage policy and acknowledgements.
@@ -190,6 +191,7 @@ const DownloadModal = ({
 	manifestFileName = 'manifest.txt',
 	metadataFileName = 'metadata-export.tsv',
 	onClose,
+	sqon,
 	selectedRows = [],
 	zipArchiveFileName = 'download_bundle.zip',
 }: {
@@ -201,6 +203,7 @@ const DownloadModal = ({
 	metadataFileName?: string;
 	onClose: () => void;
 	selectedRows: string[];
+	sqon: SQONType;
 	zipArchiveFileName?: string;
 }) => {
 	const theme: ThemeInterface = useTheme();
@@ -245,12 +248,14 @@ const DownloadModal = ({
 		if (!isLoading) {
 			handleBundleDownload();
 			if (selectedRows.length === 0) {
-				fetchReleaseData().then((data) =>
-					setSamplesCount(data?.filesByVariant?.reduce((sum, { count }) => sum + count, 0) ?? 0),
-				);
+				fetchReleaseData(sqon).then((data) => {
+					const sumGenomesPerProvince = data?.filesByVariant?.reduce((sum, { count }) => sum + count, 0);
+					const approxGenomesCount = data?.genomesCount?.value;
+					setSamplesCount(sumGenomesPerProvince || approxGenomesCount || 0);
+				});
 			}
 		}
-	}, [isLoading, handleBundleDownload, selectedRows]);
+	}, [isLoading, handleBundleDownload, selectedRows, sqon]);
 
 	return (
 		<Modal

--- a/components/pages/environmental/RepoTable/index.tsx
+++ b/components/pages/environmental/RepoTable/index.tsx
@@ -25,6 +25,7 @@ import {
 	Table,
 	TableContextProvider,
 	Toolbar,
+	useArrangerData,
 	useArrangerTheme,
 } from '@overture-stack/arranger-components';
 import {
@@ -186,6 +187,7 @@ const RepoTable = (): ReactElement => {
 	const [fileManifest, setFileManifest] = useState<SubmissionManifest[]>([]);
 	const [fileMetadata, setFileMetadata] = useState<Blob | null>(null);
 	const [selectedRows, setSelectedRows] = useState<string[]>([]);
+	const { sqon } = useArrangerData({ callerName: 'Environmental-RepoTable' });
 	const [isLoadingManifest, setIsLoadingManifest] = useState(false);
 	const [isLoadingMetadata, setIsLoadingMetadata] = useState(false);
 
@@ -297,6 +299,7 @@ const RepoTable = (): ReactElement => {
 					fileManifest={fileManifest}
 					fileMetadata={fileMetadata}
 					selectedRows={selectedRows}
+					sqon={sqon}
 					isLoading={isLoadingManifest || isLoadingMetadata}
 					metadataFileName={`wastewater-metadata-export-${today}.tsv`}
 				/>


### PR DESCRIPTION
# Description
This PR fixes an issue to display the right number of `samples` being downloaded. 

## Details
- The number displays the sum of records found by Canadian provinces (aggregation by `geo_loc_name_state_province_territory`)
- If no samples found matching Canadian provinces, then use the approx number of samples by ID (aggregation by `specimen_collector_sample_id` using cardinality precision threshold)

### Screenshot
<img width="947" height="694" alt="image" src="https://github.com/user-attachments/assets/f1005438-6f2d-4bb8-8c1f-6e0b9eb6a99d" />


## Issue:
- https://github.com/virusseq/roadmap/issues/147