### PR TITLE
Fix long text to wrap in Studies table

### DIFF
--- a/components/pages/studies/StudiesTable.tsx
+++ b/components/pages/studies/StudiesTable.tsx
@@ -105,6 +105,16 @@ const columnData = (
 	{
 		accessor: 'description',
 		Header: 'Description',
+		Cell: ({ value }: { value: string }) => (
+			<div
+				css={css`
+					white-space: normal;
+					overflow-wrap: break-word;
+				`}
+			>
+				{value}
+			</div>
+		),
 	},
 	{
 		accessor: (row) => {


### PR DESCRIPTION
# Description
Fix long text to wrap in the Description column of the Studies table.


## Solution
The table automatically adjusts to the screen size, wrapping text across multiple lines to fit properly.
<img width="1016" height="427" alt="image" src="https://github.com/user-attachments/assets/e8b45cab-29f8-4c72-ad65-f2a8d3ab9bba" />



### Tack issue
- https://github.com/imicroseq/task-tracking/issues/32