### PR TITLE
#29 Uploading the wrong filetype shows no errors.

### DIFF
--- a/components/pages/submission/Clinical/NewSubmissions/DropZone.tsx
+++ b/components/pages/submission/Clinical/NewSubmissions/DropZone.tsx
@@ -20,23 +20,25 @@
  */
 
 import { css, useTheme } from '@emotion/react';
-import { Dispatch, ReactElement, useCallback } from 'react';
+import { Dispatch, ReactElement, useCallback, type SetStateAction } from 'react';
 import { useDropzone } from 'react-dropzone';
 
 import { ButtonElement as Button } from '#components/Button';
 import DragAndDrop from '#components/theme/icons/DragAndDrop';
 
-import { ValidationActionType, ValidationParametersType } from './types';
+import type { ValidationActionType, ValidationParametersType, NoUploadErrorType } from './types';
 import { validator } from './validationHelpers';
 
 const DropZone = ({
 	disabled,
 	validationState,
 	validationDispatch,
+	setUploadError,
 }: {
 	disabled: boolean;
 	validationState: ValidationParametersType;
 	validationDispatch: Dispatch<ValidationActionType>;
+	setUploadError: Dispatch<SetStateAction<NoUploadErrorType>>;
 }): ReactElement => {
 	const theme = useTheme();
 
@@ -48,9 +50,18 @@ const DropZone = ({
 		// isFileTooLarge,
 	} = useDropzone({
 		accept: '.fa,.gz,.fasta,.tsv,text/tab-separated-values',
+		onDropRejected(fileRejections, event) {
+			setUploadError({
+				status: 'Unsupported  file type',
+				message: `We do not accept this type of file: ${fileRejections.map(({ file }) => file.name).join(', ')}`,
+			});
+		},
 		disabled,
 		onDrop: useCallback(
-			(acceptedFiles: File[]) => acceptedFiles.forEach(validator(validationState, validationDispatch)),
+			(acceptedFiles: File[]) => {
+				setUploadError({}); // clear any previous error
+				acceptedFiles.forEach(validator(validationState, validationDispatch, setUploadError))
+			},
 			[validationDispatch, validationState],
 		),
 	});

--- a/components/pages/submission/Clinical/NewSubmissions/index.tsx
+++ b/components/pages/submission/Clinical/NewSubmissions/index.tsx
@@ -96,7 +96,6 @@ const NewSubmissions = (): ReactElement => {
 	};
 
 	useEffect(() => {
-		setUploadError(noUploadError);
 		setThereAreFiles(validationState.oneTSV.length > 0 || validationState.oneOrMoreFasta.length > 0);
 	}, [validationState]);
 
@@ -201,9 +200,10 @@ const NewSubmissions = (): ReactElement => {
 				disabled={!userHasClinicalAccess}
 				validationState={validationState}
 				validationDispatch={validationDispatch}
+				setUploadError={setUploadError}
 			/>
 
-			{uploadError.message && (
+			{uploadError.status && (
 				<ErrorNotification
 					size="md"
 					title={uploadError.status}

--- a/components/pages/submission/Clinical/NewSubmissions/validationHelpers.ts
+++ b/components/pages/submission/Clinical/NewSubmissions/validationHelpers.ts
@@ -19,9 +19,9 @@
  *
  */
 
-import { Dispatch } from 'react';
+import { Dispatch, type SetStateAction } from 'react';
 
-import { ReaderCallbackType, ValidationActionType, ValidationParametersType } from './types';
+import { ReaderCallbackType, ValidationActionType, ValidationParametersType, type NoUploadErrorType } from './types';
 
 export const validationParameters = {
 	oneTSV: [], // will use only the first one, but display any added
@@ -108,7 +108,7 @@ export const minFiles = ({ oneTSV, oneOrMoreFasta }: ValidationParametersType): 
 	!!oneTSV && oneOrMoreFasta.length > 0;
 
 export const validator =
-	(state: ValidationParametersType, dispatch: Dispatch<ValidationActionType>) =>
+	(state: ValidationParametersType, dispatch: Dispatch<ValidationActionType>, setUploadError: Dispatch<SetStateAction<NoUploadErrorType>>) =>
 	(file: File): void => {
 		// TODO: create dev mode
 		// console.log('validating file', file)
@@ -130,7 +130,11 @@ export const validator =
 			}
 
 			default: {
-				return console.log(`We do not accept this type of file: ${file.name}`);
+				setUploadError({
+					status: 'Unsupported file type',
+					message: `We do not accept this type of file: ${file.name}`,
+				});
+				return ;
 			}
 		}
 	};

--- a/components/pages/submission/Environmental/NewSubmissions/DropZone.tsx
+++ b/components/pages/submission/Environmental/NewSubmissions/DropZone.tsx
@@ -63,7 +63,7 @@ const DropZone = ({
 		accept: acceptedExtensionsString,
 		onDropRejected(fileRejections, event) {
 			setUploadError({
-				status: 'Invalid File',
+				status: 'Unsupported  file type',
 				batchErrors: [
 					{
 						batchName: '',

--- a/components/pages/submission/Environmental/NewSubmissions/DropZone.tsx
+++ b/components/pages/submission/Environmental/NewSubmissions/DropZone.tsx
@@ -20,14 +20,20 @@
  */
 
 import { css, useTheme } from '@emotion/react';
-import { Dispatch, ReactElement, useCallback } from 'react';
+import { Dispatch, ReactElement, useCallback, type SetStateAction } from 'react';
 import { useDropzone } from 'react-dropzone';
 
 import { ButtonElement as Button } from '#components/Button';
 import DragAndDrop from '#components/theme/icons/DragAndDrop';
 
 import { computeMd5 } from './fileUtils';
-import { acceptedFileExtensions, SubmissionFile, ValidationAction, ValidationParameters } from './types';
+import {
+	acceptedFileExtensions,
+	type SubmissionFile,
+	type ValidationAction,
+	type ValidationParameters,
+	type NoUploadError,
+} from './types';
 import { getFileExtension, validator } from './validationHelpers';
 
 const acceptedExtensionsString = Object.values(acceptedFileExtensions)
@@ -38,10 +44,12 @@ const DropZone = ({
 	disabled,
 	validationState,
 	validationDispatch,
+	setUploadError,
 }: {
 	disabled: boolean;
 	validationState: ValidationParameters;
 	validationDispatch: Dispatch<ValidationAction>;
+	setUploadError: Dispatch<SetStateAction<NoUploadError>>;
 }): ReactElement => {
 	const theme = useTheme();
 
@@ -53,10 +61,23 @@ const DropZone = ({
 		// isFileTooLarge,
 	} = useDropzone({
 		accept: acceptedExtensionsString,
+		onDropRejected(fileRejections, event) {
+			setUploadError({
+				status: 'Invalid File',
+				batchErrors: [
+					{
+						batchName: '',
+						type: 'INVALID_FILE_EXTENSION',
+						message: fileRejections.map(({ file }) => file.name).join(', '),
+					},
+				],
+			});
+		},
 		disabled,
 		onDrop: useCallback(
 			(acceptedFiles: SubmissionFile[]) => {
 				// Compute md5 for tar.xz files and validate each files
+				setUploadError({ description: '', status: '', batchErrors: [] });
 				Promise.all(
 					acceptedFiles.map((file) =>
 						getFileExtension(file.name) === acceptedFileExtensions.TAR_XZ

--- a/components/pages/submission/Environmental/NewSubmissions/index.tsx
+++ b/components/pages/submission/Environmental/NewSubmissions/index.tsx
@@ -21,7 +21,7 @@
 
 import { css, useTheme } from '@emotion/react';
 import Router from 'next/router';
-import { ReactElement, useEffect, useReducer, useState } from 'react';
+import { ReactElement, useReducer, useState } from 'react';
 import urlJoin from 'url-join';
 
 import { ButtonElement as Button } from '#components/Button';
@@ -92,12 +92,12 @@ const NewSubmissions = (): ReactElement => {
 	const { token, userHasEnvironmentalAccess, userIsEnvironmentalAdmin, userEnvironmentalWriteScopes } =
 		useAuthContext();
 	const theme = useTheme();
-	const [thereAreFiles, setThereAreFiles] = useState(false);
 	const [filesSubmissionInstructions, setFilesSubmissionInstructions] = useState<SubmissionManifest[]>([]);
 	const [submissionId, setSubmissionId] = useState<string>('');
 	const [uploadError, setUploadError] = useState<NoUploadError>(noUploadError);
 	const [validationState, validationDispatch] = useReducer(validationReducer, validationParameters);
 	const { oneCsv, oneOrMoreTar, readyToUpload } = validationState;
+	const thereAreFiles = minFiles(validationState);
 	const [openGuideModal, setOpenGuideModal] = useState(false);
 
 	const { awaitingResponse, submitData, downloadMetadataTemplateUrl } = useEnvironmentalData('NewSubmissions');
@@ -188,11 +188,6 @@ const NewSubmissions = (): ReactElement => {
 			setSubmitError('An unexpected error occurred. Please try again later.');
 		}
 	};
-
-	useEffect(() => {
-		setUploadError(noUploadError);
-		setThereAreFiles(minFiles(validationState));
-	}, [validationState]);
 
 	const handleClearAll = () => {
 		setUploadError(noUploadError);
@@ -305,9 +300,10 @@ const NewSubmissions = (): ReactElement => {
 				disabled={!userHasEnvironmentalAccess}
 				validationState={validationState}
 				validationDispatch={validationDispatch}
+				setUploadError={setUploadError}
 			/>
 
-			{uploadError.description && (
+			{uploadError.status && (
 				<ErrorNotification
 					size="md"
 					title={uploadError.status}


### PR DESCRIPTION
# Summary
Display a message when uploading an unsupported file type.

## Details
Change is applied in both Clinical and Environmental Submissions as described bellow:

1. Environmental Submission
<img width="1422" height="992" alt="Screenshot 2026-06-09 at 8 10 49 AM" src="https://github.com/user-attachments/assets/9bef4f29-f66e-43b4-9ec0-c3e4624153a1" />


2. Clinical Submission
<img width="1422" height="992" alt="Screenshot 2026-06-09 at 8 06 41 AM" src="https://github.com/user-attachments/assets/69136343-8ad5-4ca2-a981-7af02a0aa9ef" />


## Issue related
- https://github.com/imicroseq/task-tracking/issues/29