### PR TITLE
#171 Display confirmation Submission modal

### DIFF
--- a/components/pages/submission/Clinical/NewSubmissions/index.tsx
+++ b/components/pages/submission/Clinical/NewSubmissions/index.tsx
@@ -31,6 +31,7 @@ import { LoaderWrapper } from '#components/Loader';
 import useAuthContext from '#global/hooks/useAuthContext';
 import useMuseData from '#global/hooks/useMuseData';
 import getInternalLink from '#global/utils/getInternalLink';
+import ConfirmSubmissionModal from '#components/pages/submission/ConfirmSubmissionModal';
 
 import DropZone from './DropZone';
 import ErrorMessage from './ErrorMessage';
@@ -44,6 +45,7 @@ const NewSubmissions = (): ReactElement => {
 	const { token, userHasClinicalAccess } = useAuthContext();
 	const theme = useTheme();
 	const [thereAreFiles, setThereAreFiles] = useState(false);
+	const [confirmSubmissionModalOpen, setConfirmSubmissionModalOpen] = useState(false);
 	const [uploadError, setUploadError] = useState(noUploadError);
 	const [validationState, validationDispatch] = useReducer(validationReducer, validationParameters);
 	const { oneTSV, oneOrMoreFasta, readyToUpload } = validationState;
@@ -93,6 +95,7 @@ const NewSubmissions = (): ReactElement => {
 		}
 
 		console.error(`no ${token ? 'token' : userHasClinicalAccess ? 'scopes' : 'files'} to submit`);
+		return Promise.resolve();
 	};
 
 	useEffect(() => {
@@ -368,7 +371,7 @@ const NewSubmissions = (): ReactElement => {
 										padding: 0 15px;
 									`}
 									disabled={!(readyToUpload && !uploadError.message)}
-									onClick={handleSubmit}
+									onClick={() => setConfirmSubmissionModalOpen(true)}
 								>
 									Submit Data
 								</Button>
@@ -387,6 +390,12 @@ const NewSubmissions = (): ReactElement => {
 						</tr>
 					</tfoot>
 				</table>
+				{confirmSubmissionModalOpen && (
+					<ConfirmSubmissionModal
+						onClose={() => setConfirmSubmissionModalOpen(false)}
+						onSubmit={handleSubmit}
+					/>
+				)}
 			</LoaderWrapper>
 		</article>
 	);

--- a/components/pages/submission/ConfirmSubmissionModal.tsx
+++ b/components/pages/submission/ConfirmSubmissionModal.tsx
@@ -1,0 +1,35 @@
+import { css } from '@emotion/react';
+
+import { Modal } from '#components/Modal';
+import defaultTheme from '#components/theme/index';
+
+type ConfirmSubmissionModalProps = {
+	onClose: () => void;
+	onSubmit: () => Promise<void>;
+};
+
+const ConfirmSubmissionModal = ({ onClose, onSubmit }: ConfirmSubmissionModalProps) => {
+	return (
+		<Modal
+			showActionButton={true}
+			disableActionButton={false}
+			onCloseClick={onClose}
+			onActionClick={onSubmit}
+			actionText="Confirm"
+			closeText="Cancel"
+			title={'Submit Confirmation'}
+		>
+			<p
+				css={css`
+					padding-right: 7px;
+					padding-left: 7px;
+					${defaultTheme.typography.baseFont}
+				`}
+			>
+				Please confirm that your selection is complete and ready for submission.
+			</p>
+		</Modal>
+	);
+};
+
+export default ConfirmSubmissionModal;

--- a/components/pages/submission/Environmental/NewSubmissions/index.tsx
+++ b/components/pages/submission/Environmental/NewSubmissions/index.tsx
@@ -32,6 +32,7 @@ import useAuthContext from '#global/hooks/useAuthContext';
 import useEnvironmentalData from '#global/hooks/useEnvironmentalData';
 import type { SubmissionManifest } from '#global/utils/fileManifest';
 import getInternalLink from '#global/utils/getInternalLink';
+import ConfirmSubmissionModal from '#components/pages/submission/ConfirmSubmissionModal';
 
 import DropZone from './DropZone';
 import ErrorMessage from './ErrorMessage';
@@ -92,6 +93,7 @@ const NewSubmissions = (): ReactElement => {
 	const { token, userHasEnvironmentalAccess, userIsEnvironmentalAdmin, userEnvironmentalWriteScopes } =
 		useAuthContext();
 	const theme = useTheme();
+	const [confirmSubmissionModalOpen, setConfirmSubmissionModalOpen] = useState(false);
 	const [filesSubmissionInstructions, setFilesSubmissionInstructions] = useState<SubmissionManifest[]>([]);
 	const [submissionId, setSubmissionId] = useState<string>('');
 	const [uploadError, setUploadError] = useState<NoUploadError>(noUploadError);
@@ -468,7 +470,7 @@ const NewSubmissions = (): ReactElement => {
 										!(readyToUpload && !uploadError.description) ||
 										filesSubmissionInstructions.length > 0
 									}
-									onClick={handleSubmit}
+									onClick={() => setConfirmSubmissionModalOpen(true)}
 								>
 									Submit Data
 								</Button>
@@ -502,6 +504,12 @@ const NewSubmissions = (): ReactElement => {
 								}),
 							);
 						}}
+					/>
+				)}
+				{confirmSubmissionModalOpen && (
+					<ConfirmSubmissionModal
+						onClose={() => setConfirmSubmissionModalOpen(false)}
+						onSubmit={handleSubmit}
 					/>
 				)}
 			</LoaderWrapper>


### PR DESCRIPTION
# Summary
Display a confirmation modal asking the user to verify that file selection is complete, where the user has to click the **"Confirm"** button to proceed with submission using the selected files.


## Details
- Same Modal is displayed in both "Clinical" and "Environmental" submissions
- Screenshot:
<img width="1148" height="959" alt="Screenshot 2026-06-15 at 9 26 52 AM" src="https://github.com/user-attachments/assets/6fff652e-a0f6-4224-b91f-8865e04146d5" />



## Issue
- https://github.com/imicroseq/roadmap/issues/171