### PR TITLE
#12 Improve validation errors text format

### DIFF
--- a/components/pages/submission/Clinical/NewSubmissions/index.tsx
+++ b/components/pages/submission/Clinical/NewSubmissions/index.tsx
@@ -53,50 +53,56 @@ const NewSubmissions = (): ReactElement => {
 	const { awaitingResponse, fetchMuseData } = useMuseData('NewSubmissions');
 
 	const handleSubmit = () => {
-		setConfirmSubmissionModalOpen(false);
-		if (thereAreFiles && token && userHasClinicalAccess) {
-			const formData = new FormData();
-
-			// if many TSV are available, submit only the first one along with all fastas
-			const selectedTSV = oneTSV.slice(-1)[0];
-			formData.append('files', selectedTSV, selectedTSV.name);
-			oneOrMoreFasta.forEach((fasta) => formData.append('files', fasta, fasta.name));
-
-			return fetchMuseData('submissions', { body: formData, method: 'POST' }).then((response) => {
-				switch (response.status) {
-					case 'BAD_REQUEST': {
-						setUploadError({
-							...response,
-							status: 'Your submission has errors and cannot be processed.',
-						});
-						return Promise.resolve();
-					}
-
-					case 'INTERNAL_SERVER_ERROR': {
-						console.error(response);
-						setUploadError({
-							status: 'Internal server error',
-							message: 'Your upload request has failed. Please try again later.',
-						});
-						return Promise.resolve();
-					}
-
-					default: {
-						response.submissionId
-							? Router.push(
-									getInternalLink({
-										path: urlJoin('submission', 'clinical', response.submissionId),
-									}),
-								)
-							: console.log('Unhandled response:', response);
-						return Promise.resolve();
-					}
-				}
+		if (!thereAreFiles || !token || !userHasClinicalAccess) {
+			setConfirmSubmissionModalOpen(false);
+			const errorMessage = `No ${token ? 'token' : userHasClinicalAccess ? 'scopes' : 'files'} to submit`;
+			setUploadError({
+				status: 'Submission could not be processed',
+				message: errorMessage,
 			});
+			return Promise.resolve();
 		}
 
-		console.error(`no ${token ? 'token' : userHasClinicalAccess ? 'scopes' : 'files'} to submit`);
-		return Promise.resolve();
+		
+		const formData = new FormData();
+
+		// if many TSV are available, submit only the first one along with all fastas
+		const selectedTSV = oneTSV.slice(-1)[0];
+		formData.append('files', selectedTSV, selectedTSV.name);
+		oneOrMoreFasta.forEach((fasta) => formData.append('files', fasta, fasta.name));
+
+		return fetchMuseData('submissions', { body: formData, method: 'POST' }).then((response) => {
+			setConfirmSubmissionModalOpen(false);
+			switch (response.status) {
+				case 'BAD_REQUEST': {
+					setUploadError({
+						...response,
+						status: 'Your submission has errors and cannot be processed.',
+					});
+					return Promise.resolve();
+				}
+
+				case 'INTERNAL_SERVER_ERROR': {
+					console.error(response);
+					setUploadError({
+						status: 'Internal server error',
+						message: 'Your upload request has failed. Please try again later.',
+					});
+					return Promise.resolve();
+				}
+
+				default: {
+					response.submissionId
+						? Router.push(
+								getInternalLink({
+									path: urlJoin('submission', 'clinical', response.submissionId),
+								}),
+							)
+						: console.log('Unhandled response:', response);
+					return Promise.resolve();
+				}
+			}
+		}).catch(() => setConfirmSubmissionModalOpen(false));
 	};
 
 	useEffect(() => {

--- a/components/pages/submission/Clinical/NewSubmissions/index.tsx
+++ b/components/pages/submission/Clinical/NewSubmissions/index.tsx
@@ -63,7 +63,6 @@ const NewSubmissions = (): ReactElement => {
 			return Promise.resolve();
 		}
 
-		
 		const formData = new FormData();
 
 		// if many TSV are available, submit only the first one along with all fastas
@@ -102,7 +101,14 @@ const NewSubmissions = (): ReactElement => {
 					return Promise.resolve();
 				}
 			}
-		}).catch(() => setConfirmSubmissionModalOpen(false));
+		}).catch((error) => {
+			console.error(error);
+			setUploadError({
+				status: 'Submission could not be processed',
+				message: 'An unexpected error occurred. Please try again later.',
+			});
+			setConfirmSubmissionModalOpen(false);
+		});
 	};
 
 	useEffect(() => {

--- a/components/pages/submission/Clinical/NewSubmissions/index.tsx
+++ b/components/pages/submission/Clinical/NewSubmissions/index.tsx
@@ -53,6 +53,7 @@ const NewSubmissions = (): ReactElement => {
 	const { awaitingResponse, fetchMuseData } = useMuseData('NewSubmissions');
 
 	const handleSubmit = () => {
+		setConfirmSubmissionModalOpen(false);
 		if (thereAreFiles && token && userHasClinicalAccess) {
 			const formData = new FormData();
 

--- a/components/pages/submission/Environmental/Details/Overview.tsx
+++ b/components/pages/submission/Environmental/Details/Overview.tsx
@@ -137,7 +137,7 @@ const Overview = ({
 						</p>
 					)}
 					{status && status === SubmissionStatus.OPEN && (
-						<p>
+						<span>
 							<LoaderMessage
 								inline
 								message="Status: Validation has not started"
@@ -146,10 +146,10 @@ const Overview = ({
 							{missingUploadFiles &&
 								missingUploadFiles?.length > 0 &&
 								'. Required files have not been uploaded'}
-						</p>
+						</span>
 					)}
 					{status && status === SubmissionStatus.VALIDATING && (
-						<p>
+						<span>
 							<LoaderMessage
 								inline
 								message="Status: Validation in progress"
@@ -158,7 +158,7 @@ const Overview = ({
 							{missingUploadFiles &&
 								missingUploadFiles?.length > 0 &&
 								'. Required files have not been uploaded'}
-						</p>
+						</span>
 					)}
 					{status && status === SubmissionStatus.VALID && (
 						<p>

--- a/components/pages/submission/Environmental/Details/columns.tsx
+++ b/components/pages/submission/Environmental/Details/columns.tsx
@@ -149,7 +149,7 @@ const columnData: Column<Record<string, unknown>>[] = [
 						<Details
 							summary={`Found ${updateDetails.length} detail${updateDetails.length > 1 ? 's' : ''}`}
 							style={css`
-								margin-left: 130px;
+								margin-left: 140px;
 								color: ${theme.colors.success_dark};
 							`}
 						>

--- a/components/pages/submission/Environmental/Details/columns.tsx
+++ b/components/pages/submission/Environmental/Details/columns.tsx
@@ -27,7 +27,7 @@ import Details from '#components/Details';
 import { uuidSort } from '#components/GenericTable/helpers';
 import theme from '#components/theme';
 import { Checkmark, Ellipsis, Warning } from '#components/theme/icons';
-import { UploadData } from '#global/hooks/useEnvironmentalData';
+import { RecordValidationErrorDetails, UpdateDetails, UploadData } from '#global/hooks/useEnvironmentalData';
 
 import { UploadStatus } from './types';
 
@@ -50,6 +50,14 @@ const StatusIcon = ({ status }: { status: UploadStatus }) => {
 		default:
 			return <Ellipsis size={12} />;
 	}
+};
+
+const isRecordValidationErrorDetails = (detail: UploadData['details'][number]): detail is RecordValidationErrorDetails => {
+	return typeof detail === 'object' && detail !== null && 'field' in detail && 'issue' in detail;
+};
+
+const isUpdateDetails = (detail: UploadData['details'][number]): detail is UpdateDetails => {
+	return typeof detail === 'object' && detail !== null && 'old' in detail && 'new' in detail;
 };
 
 const columnData: Column<Record<string, unknown>>[] = [
@@ -77,6 +85,8 @@ const columnData: Column<Record<string, unknown>>[] = [
 		accessor: 'status',
 		Cell: ({ row, value }: { row: Row<UploadData>; value: UploadStatus }): ReactElement => {
 			const { details, systemId, eventType } = row.original;
+			const errorDetails = details.filter(isRecordValidationErrorDetails);
+			const updateDetails = details.filter(isUpdateDetails);
 
 			return (
 				<>
@@ -92,20 +102,9 @@ const columnData: Column<Record<string, unknown>>[] = [
 						{`${eventType} ${value}${details.length ? ': ' : ''}`}
 					</span>
 
-					{value === UploadStatus.ERROR && details.length === 1 ? (
-						<span
-							css={css`
-								display: inline-block;
-								margin-left: 105px;
-								white-space: normal;
-								color: ${theme.colors.error_dark};
-							`}
-						>
-							{details[0]}
-						</span>
-					) : value === UploadStatus.ERROR && details.length > 1 ? (
+					{value === UploadStatus.ERROR && errorDetails.length > 0 ? (
 						<Details
-							summary={`Found ${details.length} details`}
+							summary={`Found ${errorDetails.length} issue${errorDetails.length > 1 ? 's' : ''}`}
 							style={css`
 								margin-left: 105px;
 								color: ${theme.colors.error_dark};
@@ -118,14 +117,29 @@ const columnData: Column<Record<string, unknown>>[] = [
 									color: ${theme.colors.error_dark};
 								`}
 							>
-								{details.map((e, i) => (
-									<li key={`error-${i}-${systemId}`}>{e}</li>
+								{errorDetails.map((error, i) => (
+									<li
+										key={`error-${i}-${systemId}`}
+										css={css`
+											margin-bottom: 10px;
+										`}
+									>
+										<strong>Field:</strong> {error.field}
+										<br />
+										<strong>Issue:</strong> {error.issue}
+										{error.value ? (
+											<>
+												<br />
+												<strong>Value:</strong> '{error.value}'
+											</>
+										) : null}
+									</li>
 								))}
 							</ol>
 						</Details>
-					) : value !== UploadStatus.ERROR && details.length > 1 ? (
+					) : value !== UploadStatus.ERROR && updateDetails.length > 0 ? (
 						<Details
-							summary={`Found ${details.length} details`}
+							summary={`Found ${updateDetails.length} detail${updateDetails.length > 1 ? 's' : ''}`}
 							style={css`
 								margin-left: 130px;
 								color: ${theme.colors.success_dark};
@@ -138,8 +152,12 @@ const columnData: Column<Record<string, unknown>>[] = [
 									color: ${theme.colors.success_dark};
 								`}
 							>
-								{details.map((e, i) => (
-									<li key={`details-${i}-${systemId}`}>{e}</li>
+								{updateDetails.map((detail, i) => (
+									<li key={`details-${i}-${systemId}`}>
+										<strong>Old:</strong> {JSON.stringify(detail.old)}
+										<br />
+										<strong>New:</strong> {JSON.stringify(detail.new)}
+									</li>
 								))}
 							</ol>
 						</Details>

--- a/components/pages/submission/Environmental/Details/columns.tsx
+++ b/components/pages/submission/Environmental/Details/columns.tsx
@@ -52,11 +52,19 @@ const StatusIcon = ({ status }: { status: UploadStatus }) => {
 	}
 };
 
-const isRecordValidationErrorDetails = (detail: UploadData['details'][number]): detail is RecordValidationErrorDetails => {
+/**
+ * Type guard to check if a detail is of type RecordValidationErrorDetails
+ */
+const isRecordValidationErrorDetails = (
+	detail: RecordValidationErrorDetails | UpdateDetails,
+): detail is RecordValidationErrorDetails => {
 	return typeof detail === 'object' && detail !== null && 'field' in detail && 'issue' in detail;
 };
 
-const isUpdateDetails = (detail: UploadData['details'][number]): detail is UpdateDetails => {
+/**
+ * Type guard to check if a detail is of type UpdateDetails
+ */
+const isUpdateDetails = (detail: RecordValidationErrorDetails | UpdateDetails): detail is UpdateDetails => {
 	return typeof detail === 'object' && detail !== null && 'old' in detail && 'new' in detail;
 };
 

--- a/components/pages/submission/Environmental/Details/columns.tsx
+++ b/components/pages/submission/Environmental/Details/columns.tsx
@@ -130,7 +130,7 @@ const columnData: Column<Record<string, unknown>>[] = [
 										{error.value ? (
 											<>
 												<br />
-												<strong>Value:</strong> '{error.value}'
+												<strong>Value:</strong> {error.value}
 											</>
 										) : null}
 									</li>

--- a/components/pages/submission/Environmental/Details/columns.tsx
+++ b/components/pages/submission/Environmental/Details/columns.tsx
@@ -125,9 +125,9 @@ const columnData: Column<Record<string, unknown>>[] = [
 									color: ${theme.colors.error_dark};
 								`}
 							>
-								{errorDetails.map((error, i) => (
+								{errorDetails.map((error, index) => (
 									<li
-										key={`error-${i}-${systemId}`}
+										key={`error-${index}-${systemId}`}
 										css={css`
 											margin-bottom: 10px;
 										`}

--- a/components/pages/submission/Environmental/NewSubmissions/DropZone.tsx
+++ b/components/pages/submission/Environmental/NewSubmissions/DropZone.tsx
@@ -29,10 +29,10 @@ import DragAndDrop from '#components/theme/icons/DragAndDrop';
 import { computeMd5 } from './fileUtils';
 import {
 	acceptedFileExtensions,
+	type BatchError,
 	type SubmissionFile,
 	type ValidationAction,
 	type ValidationParameters,
-	type NoUploadError,
 } from './types';
 import { getFileExtension, validator } from './validationHelpers';
 
@@ -49,35 +49,26 @@ const DropZone = ({
 	disabled: boolean;
 	validationState: ValidationParameters;
 	validationDispatch: Dispatch<ValidationAction>;
-	setUploadError: Dispatch<SetStateAction<NoUploadError>>;
+	setUploadError: Dispatch<SetStateAction<BatchError[]>>;
 }): ReactElement => {
 	const theme = useTheme();
 
-	const {
-		getRootProps,
-		getInputProps,
-		// isDragAccept,
-		isDragActive,
-		// isFileTooLarge,
-	} = useDropzone({
+	const { getRootProps, getInputProps, isDragActive } = useDropzone({
 		accept: acceptedExtensionsString,
 		onDropRejected(fileRejections, event) {
-			setUploadError({
-				status: 'Unsupported  file type',
-				batchErrors: [
-					{
-						batchName: '',
-						type: 'INVALID_FILE_EXTENSION',
-						message: fileRejections.map(({ file }) => file.name).join(', '),
-					},
-				],
-			});
+			setUploadError(
+				fileRejections.map(({ file }) => ({
+					type: 'INCORRECT_SECTION',
+					message: `This file couldn't be uploaded because its file type is not supported: ${file.name}`,
+					batchName: file.name,
+				})),
+			);
 		},
 		disabled,
 		onDrop: useCallback(
 			(acceptedFiles: SubmissionFile[]) => {
 				// Compute md5 for tar.xz files and validate each files
-				setUploadError({ description: '', status: '', batchErrors: [] });
+				setUploadError([]);
 				Promise.all(
 					acceptedFiles.map((file) =>
 						getFileExtension(file.name) === acceptedFileExtensions.TAR_XZ

--- a/components/pages/submission/Environmental/NewSubmissions/DropZone.tsx
+++ b/components/pages/submission/Environmental/NewSubmissions/DropZone.tsx
@@ -58,7 +58,7 @@ const DropZone = ({
 		onDropRejected(fileRejections, event) {
 			setUploadError(
 				fileRejections.map(({ file }) => ({
-					type: 'INCORRECT_SECTION',
+					type: 'INVALID_FILE_EXTENSION',
 					message: `This file couldn't be uploaded because its file type is not supported: ${file.name}`,
 					batchName: file.name,
 				})),

--- a/components/pages/submission/Environmental/NewSubmissions/ErrorMessage.tsx
+++ b/components/pages/submission/Environmental/NewSubmissions/ErrorMessage.tsx
@@ -21,15 +21,10 @@
 
 import { ReactElement } from 'react';
 
-import { BatchErrorType } from './types';
-
-const ErrorMessage = ({ type, values }: { type: BatchErrorType; values: string }): ReactElement => (
-	<>
-		<li key={type}>
-			<p>{type}:</p>
-			<span>{values}</span>
-		</li>
-	</>
+const ErrorMessage = ({ values }: { values: string }): ReactElement => (
+	<li>
+		<span>{values}</span>
+	</li>
 );
 
 export default ErrorMessage;

--- a/components/pages/submission/Environmental/NewSubmissions/index.tsx
+++ b/components/pages/submission/Environmental/NewSubmissions/index.tsx
@@ -107,7 +107,7 @@ const NewSubmissions = (): ReactElement => {
 
 	const handleSubmit = async () => {
 		if (!thereAreFiles || !token || !userHasEnvironmentalAccess) {
-			const errorMessage = `no ${token ? 'token' : userHasEnvironmentalAccess ? 'scopes' : 'files'} to submit`;
+			const errorMessage = `No ${token ? 'token' : userHasEnvironmentalAccess ? 'scopes' : 'files'} to submit`;
 			setConfirmSubmissionModalOpen(false);
 			setUploadError([{ batchName: '', message: errorMessage, type: 'FILE_READ_ERROR' }]);
 			return;

--- a/components/pages/submission/Environmental/NewSubmissions/index.tsx
+++ b/components/pages/submission/Environmental/NewSubmissions/index.tsx
@@ -38,19 +38,8 @@ import DropZone from './DropZone';
 import ErrorMessage from './ErrorMessage';
 import FileRow from './FileRow';
 import FileUploadInstructionsModal from './FileUploadInstructionsModal';
-import {
-	acceptedFileExtensions,
-	CreateSubmissionStatus,
-	NoUploadError,
-	ValidationAction,
-	type BatchError,
-	type SubmissionFile,
-} from './types';
+import { CreateSubmissionStatus, ValidationAction, type BatchError, type SubmissionFile } from './types';
 import { getFileExtension, minFiles, validationParameters, validationReducer } from './validationHelpers';
-
-const noUploadError: NoUploadError = {
-	status: '',
-};
 
 // Constants for submit parms
 export const SubmitParams = {
@@ -89,6 +78,18 @@ const buildFormData = (organizationName: string, selectedCsv: SubmissionFile, on
 	return formData;
 };
 
+const SUBMISSION_ERROR_MESSAGE_RULES = [
+	{
+		pattern: /The studyId '%s' does not exist/,
+		getMessage: (organizationName: string) => `Study ID "${organizationName}" does not exist in the system.`,
+	},
+] as const;
+
+const mapBatchErrorMessage = (rawMessage: string, organizationName: string) => {
+	const matchedRule = SUBMISSION_ERROR_MESSAGE_RULES.find((rule) => rule.pattern.test(rawMessage));
+	return matchedRule ? matchedRule.getMessage(organizationName) : rawMessage;
+};
+
 const NewSubmissions = (): ReactElement => {
 	const { token, userHasEnvironmentalAccess, userIsEnvironmentalAdmin, userEnvironmentalWriteScopes } =
 		useAuthContext();
@@ -96,7 +97,7 @@ const NewSubmissions = (): ReactElement => {
 	const [confirmSubmissionModalOpen, setConfirmSubmissionModalOpen] = useState(false);
 	const [filesSubmissionInstructions, setFilesSubmissionInstructions] = useState<SubmissionManifest[]>([]);
 	const [submissionId, setSubmissionId] = useState<string>('');
-	const [uploadError, setUploadError] = useState<NoUploadError>(noUploadError);
+	const [uploadError, setUploadError] = useState<BatchError[]>([]);
 	const [validationState, validationDispatch] = useReducer(validationReducer, validationParameters);
 	const { oneCsv, oneOrMoreTar, readyToUpload } = validationState;
 	const thereAreFiles = minFiles(validationState);
@@ -104,39 +105,28 @@ const NewSubmissions = (): ReactElement => {
 
 	const { awaitingResponse, submitData, downloadMetadataTemplateUrl } = useEnvironmentalData('NewSubmissions');
 
-	const setSubmitError = (
-		description: string,
-		status = 'Your submission has errors and cannot be processed.',
-		batchErrors?: BatchError[],
-	) => {
-		setUploadError({
-			description,
-			status,
-			batchErrors,
-		});
-	};
-
 	const handleSubmit = async () => {
+		setConfirmSubmissionModalOpen(false);
 		if (!thereAreFiles || !token || !userHasEnvironmentalAccess) {
 			const errorMessage = `no ${token ? 'token' : userHasEnvironmentalAccess ? 'scopes' : 'files'} to submit`;
-			setSubmitError(errorMessage);
-			return;
-		}
-
-		// Validate uploaded file
-		const selectedCsv = oneCsv[0];
-		if (!selectedCsv || getFileExtension(selectedCsv.name) !== acceptedFileExtensions.CSV) {
-			setSubmitError(`Please upload a .csv file.`);
+			setUploadError([{ batchName: '', message: errorMessage, type: 'FILE_READ_ERROR' }]);
 			return;
 		}
 
 		// Extract organization name from the CSV file
+		const selectedCsv = oneCsv[0];
 		const organizationName = selectedCsv.name.split('.')[0].toUpperCase();
 
 		const hasWriteAccessToOrganization =
 			userIsEnvironmentalAdmin || userEnvironmentalWriteScopes.includes(organizationName);
 		if (!hasWriteAccessToOrganization) {
-			setSubmitError(`User does not have permission to upload data for organization ${organizationName}`);
+			setUploadError([
+				{
+					batchName: '',
+					message: `User does not have permission to upload data for organization "${organizationName}"`,
+					type: 'FILE_READ_ERROR',
+				},
+			]);
 			return;
 		}
 
@@ -149,11 +139,11 @@ const NewSubmissions = (): ReactElement => {
 			switch (response.status) {
 				case CreateSubmissionStatus.PARTIAL_SUBMISSION:
 				case CreateSubmissionStatus.INVALID_SUBMISSION: {
-					console.error(`invalid submission: ${response}`);
-					setSubmitError(
-						response.description || response.batchErrors.map((e) => e.message).join(','),
-						undefined,
-						response.batchErrors,
+					setUploadError(
+						response.batchErrors.map((error) => ({
+							...error,
+							message: mapBatchErrorMessage(error.message, organizationName),
+						})),
 					);
 					break;
 				}
@@ -181,25 +171,37 @@ const NewSubmissions = (): ReactElement => {
 
 				default: {
 					console.error(response);
-					setSubmitError('Your upload request has failed. Please try again later.', 'Internal Server Error');
+					setUploadError([
+						{
+							batchName: '',
+							message: 'Your upload request has failed. Please try again later.',
+							type: 'FILE_READ_ERROR',
+						},
+					]);
 					break;
 				}
 			}
 		} catch (error) {
 			console.error(error);
-			setSubmitError('An unexpected error occurred. Please try again later.');
+			setUploadError([
+				{
+					batchName: '',
+					message: 'An unexpected error occurred. Please try again later.',
+					type: 'FILE_READ_ERROR',
+				},
+			]);
 		}
 	};
 
 	const handleClearAll = () => {
-		setUploadError(noUploadError);
+		setUploadError([]);
 		validationDispatch({ type: 'clear all' });
 	};
 
 	const handleRemoveThis =
 		({ name }: SubmissionFile) =>
 		() => {
-			setUploadError(noUploadError);
+			setUploadError([]);
 			validationDispatch({
 				type: `remove ${getFileExtension(name)}`,
 				file: name,
@@ -305,10 +307,10 @@ const NewSubmissions = (): ReactElement => {
 				setUploadError={setUploadError}
 			/>
 
-			{uploadError.status && (
+			{uploadError.length > 0 && (
 				<ErrorNotification
 					size="md"
-					title={uploadError.status}
+					title="Submission could not be processed"
 					styles={`
             align-items: center;
             box-sizing: border-box;
@@ -319,36 +321,32 @@ const NewSubmissions = (): ReactElement => {
             width: 100%;
           `}
 				>
-					{uploadError.description}
+					<ul
+						css={css`
+							margin: 10px 0 0;
+							padding-left: 0;
 
-					{uploadError?.batchErrors && (
-						<ul
-							css={css`
-								margin: 10px 0 0;
-								padding-left: 0;
+							p {
+								margin-bottom: 0.5rem;
+							}
 
-								p {
-									margin-bottom: 0.5rem;
-								}
+							li:first-of-type p {
+								margin-top: 0;
+							}
 
-								li:first-of-type p {
-									margin-top: 0;
-								}
-
-								span {
-									display: block;
-									font-size: 13px;
-								}
-							`}
-						>
-							{uploadError?.batchErrors.map(({ message, type }) => (
-								<ErrorMessage
-									type={type}
-									values={message}
-								/>
-							))}
-						</ul>
-					)}
+							span {
+								display: block;
+								font-size: 13px;
+							}
+						`}
+					>
+						{uploadError.map(({ message }, index) => (
+							<ErrorMessage
+								key={`upload-error-${index}`}
+								values={message}
+							/>
+						))}
+					</ul>
 				</ErrorNotification>
 			)}
 
@@ -467,7 +465,7 @@ const NewSubmissions = (): ReactElement => {
 										padding: 0 15px;
 									`}
 									disabled={
-										!(readyToUpload && !uploadError.description) ||
+										!(readyToUpload && uploadError.length === 0) ||
 										filesSubmissionInstructions.length > 0
 									}
 									onClick={() => setConfirmSubmissionModalOpen(true)}

--- a/components/pages/submission/Environmental/NewSubmissions/index.tsx
+++ b/components/pages/submission/Environmental/NewSubmissions/index.tsx
@@ -106,9 +106,9 @@ const NewSubmissions = (): ReactElement => {
 	const { awaitingResponse, submitData, downloadMetadataTemplateUrl } = useEnvironmentalData('NewSubmissions');
 
 	const handleSubmit = async () => {
-		setConfirmSubmissionModalOpen(false);
 		if (!thereAreFiles || !token || !userHasEnvironmentalAccess) {
 			const errorMessage = `no ${token ? 'token' : userHasEnvironmentalAccess ? 'scopes' : 'files'} to submit`;
+			setConfirmSubmissionModalOpen(false);
 			setUploadError([{ batchName: '', message: errorMessage, type: 'FILE_READ_ERROR' }]);
 			return;
 		}
@@ -120,6 +120,7 @@ const NewSubmissions = (): ReactElement => {
 		const hasWriteAccessToOrganization =
 			userIsEnvironmentalAdmin || userEnvironmentalWriteScopes.includes(organizationName);
 		if (!hasWriteAccessToOrganization) {
+			setConfirmSubmissionModalOpen(false);
 			setUploadError([
 				{
 					batchName: '',
@@ -135,6 +136,7 @@ const NewSubmissions = (): ReactElement => {
 		// Submit data
 		try {
 			const response = await submitData({ body: formData });
+			setConfirmSubmissionModalOpen(false);
 
 			switch (response.status) {
 				case CreateSubmissionStatus.PARTIAL_SUBMISSION:
@@ -182,6 +184,7 @@ const NewSubmissions = (): ReactElement => {
 				}
 			}
 		} catch (error) {
+			setConfirmSubmissionModalOpen(false);
 			console.error(error);
 			setUploadError([
 				{

--- a/components/pages/submission/Environmental/NewSubmissions/types.ts
+++ b/components/pages/submission/Environmental/NewSubmissions/types.ts
@@ -51,19 +51,9 @@ export type BatchError = {
 	type: BatchErrorType;
 };
 
-/**
- * Error Response from the submission service
- */
-export type NoUploadError = {
-	batchErrors?: BatchError[];
-	description?: string;
-	status: string;
-};
-
 export type CreateSubmissionResult = {
 	submissionId?: number;
 	status: CreateSubmissionStatus;
-	description: string;
 	submissionManifest: SubmissionManifest[];
 	inProcessEntities: string[];
 	batchErrors: BatchError[];

--- a/global/hooks/useEnvironmentalData/index.ts
+++ b/global/hooks/useEnvironmentalData/index.ts
@@ -320,7 +320,7 @@ const useEnvironmentalData = (origin: string) => {
 						submitterSampleId: '',
 						submissionId,
 						eventType: EventType.UPDATE,
-						details: updateDetails.length ? updateDetails : errorDetails,
+						details: errorDetails.length ? errorDetails : updateDetails,
 						organization,
 						originalFilePair: [''],
 						status,

--- a/global/hooks/useEnvironmentalData/index.ts
+++ b/global/hooks/useEnvironmentalData/index.ts
@@ -33,6 +33,7 @@ import {
 	SubmissionStatus,
 	type CommitSubmissionResult,
 	type ErrorDetails,
+	type RecordValidationErrorDetails,
 	type SubmissionFile,
 	type SubmissionRecordsResponse,
 	type SubmissionSummary,
@@ -242,7 +243,7 @@ const useEnvironmentalData = (origin: string) => {
 	};
 
 	const resolveUploadStatus = (
-		errorDetails: string[],
+		errorDetails: RecordValidationErrorDetails[],
 		status: SubmissionStatus,
 		isUploadPending: boolean,
 		finalOnCommitted = false,
@@ -304,10 +305,7 @@ const useEnvironmentalData = (origin: string) => {
 				}
 
 				case 'UPDATES': {
-					const updateDetails = [
-						JSON.stringify({ old: item.value.old }),
-						JSON.stringify({ new: item.value.new }),
-					];
+					const updateDetails = [{ old: item.value.old, new: item.value.new }];
 
 					const status = resolveUploadStatus(errorDetails, submissionStatus, false, true);
 
@@ -453,16 +451,23 @@ const useEnvironmentalData = (origin: string) => {
 	 * Retrieves formatted error message for a specific index from a list of errors
 	 * @param errors
 	 * @param index
-	 * @returns An array of formatted error messages
+	 * @returns An array of structured error details
 	 */
-	const getErrorDetailsMessage = (errors: ErrorDetails[], index: number): string[] => {
+	const getErrorDetailsMessage = (errors: ErrorDetails[], index: number): RecordValidationErrorDetails[] => {
 		const errorDetails = errors.filter((error) => error.index === index);
 
 		const message = errorDetails.map((err) => {
-			const valuePart = err.fieldValue ? `- Value: '${err.fieldValue}'` : '';
-			const errorsPart = err.errors ? `- Details: '${err.errors[0].message.replace(/\.+$/, '')}'` : '';
+			let errorsPart = err.errors ? `${err.errors[0].message.replace(/\.+$/, '')}` : '';
 
-			return `${err.reason} - Field: '${err.fieldName}' ${valuePart} ${errorsPart}`;
+			if (err.reason === 'UNRECOGNIZED_FIELD' && !errorsPart) {
+				errorsPart = 'This field is not recognized in the schema';
+			}
+
+			return {
+				field: err.fieldName,
+				issue: errorsPart || 'Unknown validation issue',
+				value: err.fieldValue,
+			};
 		});
 
 		return message;

--- a/global/hooks/useEnvironmentalData/index.ts
+++ b/global/hooks/useEnvironmentalData/index.ts
@@ -49,6 +49,13 @@ const useEnvironmentalData = (origin: string) => {
 	const { fetchWithAuth, user } = useAuthContext();
 	const [awaitingResponse, setAwaitingResponse] = useState(false);
 
+	const ERROR_REASON_MESSAGES: Record<string, string> = {
+		INVALID_BY_UNIQUE: 'This value must be unique',
+		INVALID_BY_UNIQUE_KEY: 'This violates the uniqueKey constraint',
+		INVALID_VALUE_TYPE: 'This value is not of the expected type',
+		UNRECOGNIZED_FIELD: 'This field is not recognized in the schema',
+	};
+
 	// For reference: https://submission-service.dev.virusseq-dataportal.ca/api-docs/
 	const handleRequest = async ({
 		url,
@@ -459,8 +466,8 @@ const useEnvironmentalData = (origin: string) => {
 		const message = errorDetails.map((err) => {
 			let errorsPart = err.errors ? `${err.errors[0].message.replace(/\.+$/, '')}` : '';
 
-			if (err.reason === 'UNRECOGNIZED_FIELD' && !errorsPart) {
-				errorsPart = 'This field is not recognized in the schema';
+			if (!errorsPart && err.reason in ERROR_REASON_MESSAGES) {
+				errorsPart = ERROR_REASON_MESSAGES[err.reason];
 			}
 
 			return {

--- a/global/hooks/useEnvironmentalData/index.ts
+++ b/global/hooks/useEnvironmentalData/index.ts
@@ -464,7 +464,7 @@ const useEnvironmentalData = (origin: string) => {
 		const errorDetails = errors.filter((error) => error.index === index);
 
 		const message = errorDetails.map((err) => {
-			let errorsPart = err.errors ? `${err.errors[0].message.replace(/\.+$/, '')}` : '';
+			let errorsPart = err.errors?.[0]?.message?.replace(/\.+$/, '') || '';
 
 			if (!errorsPart && err.reason in ERROR_REASON_MESSAGES) {
 				errorsPart = ERROR_REASON_MESSAGES[err.reason];

--- a/global/hooks/useEnvironmentalData/types.ts
+++ b/global/hooks/useEnvironmentalData/types.ts
@@ -30,10 +30,21 @@ export type SubmissionOverview = {
 	status: SubmissionStatus;
 };
 
+export type RecordValidationErrorDetails = {
+	field: string;
+	issue: string;
+	value?: string;
+};
+
+export type UpdateDetails = {
+	old: DataRecord;
+	new: DataRecord;
+};
+
 export type UploadData = {
 	systemId: string | null;
 	eventType: EventType;
-	details: string[];
+	details: RecordValidationErrorDetails[] | UpdateDetails[];
 	originalFilePair: string[];
 	status: UploadStatus;
 	organization: string;


### PR DESCRIPTION
# Summary
Improvements on displaying Errors on new **Environmental** submission page, and submission details page. 

## Details
1. **Improvements on displaying the validation errors.** 
Each error has a **Field** and **Issue**  to improve readability. Created a mapping of validation error codes to be translated to a User friendly texts
<img width="1440" height="319" alt="image" src="https://github.com/user-attachments/assets/f1153ca2-3d50-4e3e-a2d1-4601dd1fceff" />

2. **Improvements on displaying file submission errors**
Each error is added to an unsorted list, it reads only the description of the error. Created a mapping of errors to be translated to a User firendly texts.
<img width="570" height="397" alt="Screenshot 2026-06-25 at 10 46 21 AM" src="https://github.com/user-attachments/assets/98b640a6-a261-40b9-84d3-09a49dba420b" />



## Issue related
- https://github.com/imicroseq/task-tracking/issues/12
