### PR TITLE
Append sequencing files to open submissions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -68,4 +68,12 @@ module.exports = {
 			version: 'detect',
 		},
 	},
+	overrides: [
+		{
+			files: ['**/*.test.js', '**/*.test.jsx', '**/*.test.ts', '**/*.test.tsx'],
+			env: {
+				jest: true,
+			},
+		},
+	],
 };

--- a/components/pages/submission/ConfirmSubmissionModal.tsx
+++ b/components/pages/submission/ConfirmSubmissionModal.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import { ReactNode } from 'react';
 
 import { Modal } from '#components/Modal';
 import defaultTheme from '#components/theme/index';
@@ -6,9 +7,10 @@ import defaultTheme from '#components/theme/index';
 type ConfirmSubmissionModalProps = {
 	onClose: () => void;
 	onSubmit: () => Promise<void>;
+	children?: ReactNode;
 };
 
-const ConfirmSubmissionModal = ({ onClose, onSubmit }: ConfirmSubmissionModalProps) => {
+const ConfirmSubmissionModal = ({ onClose, onSubmit, children }: ConfirmSubmissionModalProps) => {
 	return (
 		<Modal
 			showActionButton={true}
@@ -26,7 +28,7 @@ const ConfirmSubmissionModal = ({ onClose, onSubmit }: ConfirmSubmissionModalPro
 					${defaultTheme.typography.baseFont}
 				`}
 			>
-				Please confirm that your selection is complete and ready for submission.
+				{children ?? 'Please confirm that your selection is complete and ready for submission.'}
 			</p>
 		</Modal>
 	);

--- a/components/pages/submission/Environmental/NewSubmissions/index.tsx
+++ b/components/pages/submission/Environmental/NewSubmissions/index.tsx
@@ -21,7 +21,7 @@
 
 import { css, useTheme } from '@emotion/react';
 import Router from 'next/router';
-import { ReactElement, useReducer, useState } from 'react';
+import { ReactElement, useEffect, useReducer, useState } from 'react';
 import urlJoin from 'url-join';
 
 import { ButtonElement as Button } from '#components/Button';
@@ -29,7 +29,7 @@ import ErrorNotification from '#components/ErrorNotification';
 import StyledLink from '#components/Link';
 import { LoaderWrapper } from '#components/Loader';
 import useAuthContext from '#global/hooks/useAuthContext';
-import useEnvironmentalData from '#global/hooks/useEnvironmentalData';
+import useEnvironmentalData, { type SubmissionSummary } from '#global/hooks/useEnvironmentalData';
 import type { SubmissionManifest } from '#global/utils/fileManifest';
 import getInternalLink from '#global/utils/getInternalLink';
 import ConfirmSubmissionModal from '#components/pages/submission/ConfirmSubmissionModal';
@@ -39,44 +39,15 @@ import ErrorMessage from './ErrorMessage';
 import FileRow from './FileRow';
 import FileUploadInstructionsModal from './FileUploadInstructionsModal';
 import { CreateSubmissionStatus, ValidationAction, type BatchError, type SubmissionFile } from './types';
-import { getFileExtension, minFiles, validationParameters, validationReducer } from './validationHelpers';
-
-// Constants for submit parms
-export const SubmitParams = {
-	ORGANIZATION: 'organization' as const,
-	ENTITY_NAME: 'entityName' as const,
-	SUBMISSION_FILE: 'submissionFile' as const,
-	SEQUENCING_METADATA: 'sequencingMetadata' as const,
-};
-
-// Constants for file metadata
-export const SequencingMetadataDefaults = {
-	FILE_ACCESS: 'open' as const,
-	FILE_TYPE: 'TAR' as const,
-};
-
-const buildFormData = (organizationName: string, selectedCsv: SubmissionFile, oneOrMoreTar: SubmissionFile[]) => {
-	const formData = new FormData();
-	formData.append(SubmitParams.ORGANIZATION, organizationName);
-	formData.append(SubmitParams.ENTITY_NAME, 'sample');
-	formData.append(SubmitParams.SUBMISSION_FILE, selectedCsv);
-
-	if (oneOrMoreTar.length > 0) {
-		formData.append(
-			SubmitParams.SEQUENCING_METADATA,
-			JSON.stringify(
-				oneOrMoreTar.map((tarFile: SubmissionFile) => ({
-					fileName: tarFile.name,
-					fileSize: tarFile.size,
-					fileMd5sum: tarFile.md5,
-					fileAccess: SequencingMetadataDefaults.FILE_ACCESS,
-					fileType: SequencingMetadataDefaults.FILE_TYPE,
-				})),
-			),
-		);
-	}
-	return formData;
-};
+import {
+	buildFormData,
+	getConfirmSubmissionMessage,
+	getFileExtension,
+	getTarOnlyEligibility,
+	minFiles,
+	validationParameters,
+	validationReducer,
+} from './validationHelpers';
 
 const SUBMISSION_ERROR_MESSAGE_RULES = [
 	{
@@ -91,7 +62,7 @@ const mapBatchErrorMessage = (rawMessage: string, organizationName: string) => {
 };
 
 const NewSubmissions = (): ReactElement => {
-	const { token, userHasEnvironmentalAccess, userIsEnvironmentalAdmin, userEnvironmentalWriteScopes } =
+	const { token, user, userHasEnvironmentalAccess, userIsEnvironmentalAdmin, userEnvironmentalWriteScopes } =
 		useAuthContext();
 	const theme = useTheme();
 	const [confirmSubmissionModalOpen, setConfirmSubmissionModalOpen] = useState(false);
@@ -102,8 +73,36 @@ const NewSubmissions = (): ReactElement => {
 	const { oneCsv, oneOrMoreTar, readyToUpload } = validationState;
 	const thereAreFiles = minFiles(validationState);
 	const [openGuideModal, setOpenGuideModal] = useState(false);
+	const [previousSubmission, setPreviousSubmission] = useState<SubmissionSummary | undefined>(undefined);
 
-	const { awaitingResponse, submitData, downloadMetadataTemplateUrl } = useEnvironmentalData('NewSubmissions');
+	const { awaitingResponse, submitData, downloadMetadataTemplateUrl, fetchPreviousSubmissions } =
+		useEnvironmentalData('NewSubmissions');
+
+	useEffect(() => {
+		if (!token || !userHasEnvironmentalAccess) {
+			setPreviousSubmission(undefined);
+			return;
+		}
+
+		const controller = new AbortController();
+
+		fetchPreviousSubmissions({
+			username: user?.email,
+			signal: controller.signal,
+			page: 1,
+			pageSize: 1,
+		}).then((previousSubmission) => {
+			if (controller.signal.aborted) {
+				return;
+			}
+			const submission = previousSubmission.data[0];
+			setPreviousSubmission(submission);
+		});
+
+		return () => controller.abort();
+	}, [token, userHasEnvironmentalAccess]);
+
+	const tarOnlyEligibility = getTarOnlyEligibility(previousSubmission);
 
 	const handleSubmit = async () => {
 		if (!thereAreFiles || !token || !userHasEnvironmentalAccess) {
@@ -113,9 +112,26 @@ const NewSubmissions = (): ReactElement => {
 			return;
 		}
 
-		// Extract organization name from the CSV file
+		// Extract organization name from the CSV file, or from the previous submission
+		// when this is a CSV-less (sequencing-files-only) submission
 		const selectedCsv = oneCsv[0];
-		const organizationName = selectedCsv.name.split('.')[0].toUpperCase();
+		let organizationName: string;
+
+		if (selectedCsv) {
+			organizationName = selectedCsv.name.split('.')[0].toUpperCase();
+		} else if (tarOnlyEligibility && previousSubmission?.organization) {
+			organizationName = previousSubmission.organization || '';
+		} else {
+			setConfirmSubmissionModalOpen(false);
+			setUploadError([
+				{
+					batchName: '',
+					message: 'Unable to determine organization name from CSV file or previous submission',
+					type: 'INCORRECT_SECTION',
+				},
+			]);
+			return;
+		}
 
 		const hasWriteAccessToOrganization =
 			userIsEnvironmentalAdmin || userEnvironmentalWriteScopes.includes(organizationName);
@@ -310,6 +326,41 @@ const NewSubmissions = (): ReactElement => {
 				setUploadError={setUploadError}
 			/>
 
+			{previousSubmission?.status === 'VALID' && (
+				<p
+					css={css`
+						padding: 20px;
+						margin: 0px;
+						${theme.typography.regular}
+						background-color: ${theme.colors.warning_dark};
+						border-radius: 8px;
+						box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+						padding: 10px;
+						border: 1px solid ${theme.colors.grey_3};
+						margin: 10px 10px;
+					`}
+				>
+					You have a pending valid submission <strong>#{previousSubmission.id}</strong> for organization{' '}
+					<strong>{previousSubmission.organization}</strong>. <br />
+					1. Go to the{' '}
+					<StyledLink
+						href={getInternalLink({
+							path: urlJoin('submission', 'environmental', previousSubmission.id.toString()),
+						})}
+					>
+						<strong>submission #{previousSubmission.id}</strong>
+					</StyledLink>{' '}
+					details page to review and continue further instructions for the submission.
+					<br />
+					2. To add more sequencing file(s) to the submission <strong>#{previousSubmission.id}</strong>,
+					select only <span className="code">.tar.xz</span> files in the area above without any{' '}
+					<span className="code">.csv</span> files
+					<br />
+					3. To cancel the pending submission <strong>#{previousSubmission.id}</strong> and start a new one,
+					select a <span className="code">.csv</span> file in the area above.
+				</p>
+			)}
+
 			{uploadError.length > 0 && (
 				<ErrorNotification
 					size="md"
@@ -469,13 +520,14 @@ const NewSubmissions = (): ReactElement => {
 									`}
 									disabled={
 										!(readyToUpload && uploadError.length === 0) ||
-										filesSubmissionInstructions.length > 0
+										filesSubmissionInstructions.length > 0 ||
+										(!tarOnlyEligibility && validationState.oneCsv.length !== 1)
 									}
 									onClick={() => setConfirmSubmissionModalOpen(true)}
 								>
 									Submit Data
 								</Button>
-								{thereAreFiles && validationState.oneCsv.length !== 1 && (
+								{thereAreFiles && validationState.oneCsv.length !== 1 && !tarOnlyEligibility && (
 									<p
 										css={css`
 											color: ${theme.colors.error_dark};
@@ -511,7 +563,9 @@ const NewSubmissions = (): ReactElement => {
 					<ConfirmSubmissionModal
 						onClose={() => setConfirmSubmissionModalOpen(false)}
 						onSubmit={handleSubmit}
-					/>
+					>
+						{getConfirmSubmissionMessage(validationState, previousSubmission)}
+					</ConfirmSubmissionModal>
 				)}
 			</LoaderWrapper>
 		</article>

--- a/components/pages/submission/Environmental/NewSubmissions/index.tsx
+++ b/components/pages/submission/Environmental/NewSubmissions/index.tsx
@@ -42,9 +42,13 @@ import { CreateSubmissionStatus, ValidationAction, type BatchError, type Submiss
 import {
 	buildFormData,
 	getConfirmSubmissionMessage,
+	isCsvRequiredButMissing,
 	getFileExtension,
-	getTarOnlyEligibility,
-	minFiles,
+	isSubmissionReadyForUpload,
+	isTarOnlySubmissionEligible,
+	hasSubmissionBlockingIssues,
+	hasFiles,
+	shouldEnableSubmitButton,
 	validationParameters,
 	validationReducer,
 } from './validationHelpers';
@@ -70,8 +74,8 @@ const NewSubmissions = (): ReactElement => {
 	const [submissionId, setSubmissionId] = useState<string>('');
 	const [uploadError, setUploadError] = useState<BatchError[]>([]);
 	const [validationState, validationDispatch] = useReducer(validationReducer, validationParameters);
-	const { oneCsv, oneOrMoreTar, readyToUpload } = validationState;
-	const thereAreFiles = minFiles(validationState);
+	const { oneCsv, oneOrMoreTar } = validationState;
+	const thereAreFiles = hasFiles(validationState);
 	const [openGuideModal, setOpenGuideModal] = useState(false);
 	const [previousSubmission, setPreviousSubmission] = useState<SubmissionSummary | undefined>(undefined);
 
@@ -100,9 +104,27 @@ const NewSubmissions = (): ReactElement => {
 		});
 
 		return () => controller.abort();
-	}, [token, userHasEnvironmentalAccess]);
+	}, [token, user?.email, userHasEnvironmentalAccess]);
 
-	const tarOnlyEligibility = getTarOnlyEligibility(previousSubmission);
+	const isTarOnlyEligible = isTarOnlySubmissionEligible(previousSubmission);
+	const isCsvRequiredButMissingForSubmission = isCsvRequiredButMissing({
+		oneCsv,
+		isTarOnlySubmissionEligible: isTarOnlyEligible,
+	});
+	const isSubmissionReady = isSubmissionReadyForUpload({
+		oneCsv,
+		oneOrMoreTar,
+		isTarOnlySubmissionEligible: isTarOnlyEligible,
+	});
+	const hasBlockingIssues = hasSubmissionBlockingIssues({
+		uploadError,
+		filesSubmissionInstructions,
+		isCsvRequiredButMissing: isCsvRequiredButMissingForSubmission,
+	});
+	const enableSubmitButton = shouldEnableSubmitButton({
+		isSubmissionReadyForUpload: isSubmissionReady,
+		hasSubmissionBlockingIssues: hasBlockingIssues,
+	});
 
 	const handleSubmit = async () => {
 		if (!thereAreFiles || !token || !userHasEnvironmentalAccess) {
@@ -119,7 +141,7 @@ const NewSubmissions = (): ReactElement => {
 
 		if (selectedCsv) {
 			organizationName = selectedCsv.name.split('.')[0].toUpperCase();
-		} else if (tarOnlyEligibility && previousSubmission?.organization) {
+		} else if (isTarOnlyEligible && previousSubmission) {
 			organizationName = previousSubmission.organization || '';
 		} else {
 			setConfirmSubmissionModalOpen(false);
@@ -326,7 +348,7 @@ const NewSubmissions = (): ReactElement => {
 				setUploadError={setUploadError}
 			/>
 
-			{previousSubmission?.status === 'VALID' && (
+			{previousSubmission && isTarOnlyEligible && (
 				<p
 					css={css`
 						${theme.typography.regular}
@@ -514,16 +536,12 @@ const NewSubmissions = (): ReactElement => {
 										height: 34px;
 										padding: 0 15px;
 									`}
-									disabled={
-										!(readyToUpload && uploadError.length === 0) ||
-										filesSubmissionInstructions.length > 0 ||
-										(!tarOnlyEligibility && validationState.oneCsv.length !== 1)
-									}
+									disabled={!enableSubmitButton}
 									onClick={() => setConfirmSubmissionModalOpen(true)}
 								>
 									Submit Data
 								</Button>
-								{thereAreFiles && validationState.oneCsv.length !== 1 && !tarOnlyEligibility && (
+								{thereAreFiles && isCsvRequiredButMissingForSubmission && (
 									<p
 										css={css`
 											color: ${theme.colors.error_dark};

--- a/components/pages/submission/Environmental/NewSubmissions/index.tsx
+++ b/components/pages/submission/Environmental/NewSubmissions/index.tsx
@@ -21,7 +21,7 @@
 
 import { css, useTheme } from '@emotion/react';
 import Router from 'next/router';
-import { ReactElement, useEffect, useReducer, useState } from 'react';
+import { ReactElement, useEffect, useReducer, useRef, useState } from 'react';
 import urlJoin from 'url-join';
 
 import { ButtonElement as Button } from '#components/Button';
@@ -81,6 +81,11 @@ const NewSubmissions = (): ReactElement => {
 
 	const { awaitingResponse, submitData, downloadMetadataTemplateUrl, fetchPreviousSubmissions } =
 		useEnvironmentalData('NewSubmissions');
+	const fetchPreviousSubmissionsRef = useRef(fetchPreviousSubmissions);
+
+	useEffect(() => {
+		fetchPreviousSubmissionsRef.current = fetchPreviousSubmissions;
+	}, [fetchPreviousSubmissions]);
 
 	useEffect(() => {
 		if (!token || !userHasEnvironmentalAccess) {
@@ -90,18 +95,20 @@ const NewSubmissions = (): ReactElement => {
 
 		const controller = new AbortController();
 
-		fetchPreviousSubmissions({
-			username: user?.email,
-			signal: controller.signal,
-			page: 1,
-			pageSize: 1,
-		}).then((previousSubmission) => {
-			if (controller.signal.aborted) {
-				return;
-			}
+		fetchPreviousSubmissionsRef
+			.current({
+				username: user?.email,
+				signal: controller.signal,
+				page: 1,
+				pageSize: 1,
+			})
+			.then((previousSubmission) => {
+				if (controller.signal.aborted) {
+					return;
+				}
 
-			setPreviousSubmission(previousSubmission?.data?.[0]);
-		});
+				setPreviousSubmission(previousSubmission?.data?.[0]);
+			});
 
 		return () => controller.abort();
 	}, [token, user?.email, userHasEnvironmentalAccess]);

--- a/components/pages/submission/Environmental/NewSubmissions/index.tsx
+++ b/components/pages/submission/Environmental/NewSubmissions/index.tsx
@@ -340,9 +340,11 @@ const NewSubmissions = (): ReactElement => {
 						margin: 10px 10px;
 					`}
 				>
-					You have a pending valid submission <strong>#{previousSubmission.id}</strong> for organization{' '}
-					<strong>{previousSubmission.organization}</strong>. <br />
-					1. Go to the{' '}
+					You have a pending valid submission <strong>#{previousSubmission.id}</strong> for study{' '}
+					<strong>{previousSubmission.organization}</strong>. You have three options: <br />
+					1. <strong>Add sequencing files</strong> - Upload only <span className="code">.tar.xz</span> files
+					in the area above to add sequence file(s) to this existing submission. <br />
+					2. <strong>Review your submission</strong> - Go to the{' '}
 					<StyledLink
 						href={getInternalLink({
 							path: urlJoin('submission', 'environmental', previousSubmission.id.toString()),
@@ -350,14 +352,9 @@ const NewSubmissions = (): ReactElement => {
 					>
 						<strong>submission #{previousSubmission.id}</strong>
 					</StyledLink>{' '}
-					details page to review and continue further instructions for the submission.
+					details page to review or continue this submission.
 					<br />
-					2. To add more sequencing file(s) to the submission <strong>#{previousSubmission.id}</strong>,
-					select only <span className="code">.tar.xz</span> files in the area above without any{' '}
-					<span className="code">.csv</span> files
-					<br />
-					3. To cancel the pending submission <strong>#{previousSubmission.id}</strong> and start a new one,
-					select a <span className="code">.csv</span> file in the area above.
+					3. <strong>Start over</strong> - Cancel the pending submission and start a new one by uploading a <span className="code">.csv</span> file.
 				</p>
 			)}
 

--- a/components/pages/submission/Environmental/NewSubmissions/index.tsx
+++ b/components/pages/submission/Environmental/NewSubmissions/index.tsx
@@ -95,8 +95,8 @@ const NewSubmissions = (): ReactElement => {
 			if (controller.signal.aborted) {
 				return;
 			}
-			const submission = previousSubmission.data[0];
-			setPreviousSubmission(submission);
+
+			setPreviousSubmission(previousSubmission?.data?.[0]);
 		});
 
 		return () => controller.abort();
@@ -354,7 +354,8 @@ const NewSubmissions = (): ReactElement => {
 					</StyledLink>{' '}
 					details page to review or continue this submission.
 					<br />
-					3. <strong>Start over</strong> - Cancel the pending submission and start a new one by uploading a <span className="code">.csv</span> file.
+					3. <strong>Start over</strong> - Cancel the pending submission and start a new one by uploading a{' '}
+					<span className="code">.csv</span> file.
 				</p>
 			)}
 

--- a/components/pages/submission/Environmental/NewSubmissions/index.tsx
+++ b/components/pages/submission/Environmental/NewSubmissions/index.tsx
@@ -329,15 +329,13 @@ const NewSubmissions = (): ReactElement => {
 			{previousSubmission?.status === 'VALID' && (
 				<p
 					css={css`
-						padding: 20px;
-						margin: 0px;
 						${theme.typography.regular}
 						background-color: ${theme.colors.warning_dark};
+						border: 1px solid ${theme.colors.grey_3};
 						border-radius: 8px;
 						box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-						padding: 10px;
-						border: 1px solid ${theme.colors.grey_3};
 						margin: 10px 10px;
+						padding: 10px;
 					`}
 				>
 					You have a pending valid submission <strong>#{previousSubmission.id}</strong> for study{' '}

--- a/components/pages/submission/Environmental/NewSubmissions/types.ts
+++ b/components/pages/submission/Environmental/NewSubmissions/types.ts
@@ -20,6 +20,7 @@
  */
 
 import type { SubmissionManifest } from '#/global/utils/fileManifest';
+import type { SubmissionSummary } from '#/global/hooks/useEnvironmentalData';
 
 /**
  * Enum used in the Reponse on Create new Submissions
@@ -65,8 +66,7 @@ export const acceptedFileExtensions = {
 	XZ: 'xz',
 } as const;
 
-export type AcceptedFileExtension =
-	(typeof acceptedFileExtensions)[keyof typeof acceptedFileExtensions];
+export type AcceptedFileExtension = (typeof acceptedFileExtensions)[keyof typeof acceptedFileExtensions];
 
 export interface SubmissionFile extends File {
 	md5?: string;
@@ -89,4 +89,5 @@ export type ValidationParameters = {
 	oneCsv: SubmissionFile[];
 	oneOrMoreTar: SubmissionFile[];
 	readyToUpload: boolean;
+	previousSubmission?: SubmissionSummary;
 };

--- a/components/pages/submission/Environmental/NewSubmissions/validationHelpers.test.js
+++ b/components/pages/submission/Environmental/NewSubmissions/validationHelpers.test.js
@@ -22,6 +22,7 @@
 const {
 	buildFormData,
 	getConfirmSubmissionMessage,
+	isFileSelectionReadyForUpload,
 	isSubmissionReadyForUpload,
 	isTarOnlySubmissionEligible,
 	validationParameters,
@@ -115,6 +116,20 @@ describe('isSubmissionReadyForUpload', () => {
 				isTarOnlySubmissionEligible: false,
 			}),
 		).toBe(false);
+	});
+});
+
+describe('isFileSelectionReadyForUpload', () => {
+	it('is true when there is exactly one CSV file', () => {
+		expect(isFileSelectionReadyForUpload({ oneCsv: [csvFile], oneOrMoreTar: [] })).toBe(true);
+	});
+
+	it('is true when there is at least one tar file', () => {
+		expect(isFileSelectionReadyForUpload({ oneCsv: [], oneOrMoreTar: [tarFile] })).toBe(true);
+	});
+
+	it('is false when there are no files', () => {
+		expect(isFileSelectionReadyForUpload({ oneCsv: [], oneOrMoreTar: [] })).toBe(false);
 	});
 });
 

--- a/components/pages/submission/Environmental/NewSubmissions/validationHelpers.test.js
+++ b/components/pages/submission/Environmental/NewSubmissions/validationHelpers.test.js
@@ -88,30 +88,32 @@ describe('getTarOnlyEligibility', () => {
 describe('getConfirmSubmissionMessage', () => {
 	it('mentions the sequence file count (0) when there are no tar files', () => {
 		const state = { oneCsv: [csvFile], oneOrMoreTar: [], readyToUpload: true };
+		const organizationName = csvFile.name.split('.')[0].toUpperCase();
 		expect(getConfirmSubmissionMessage(state)).toBe(
-			'Please confirm that your selection (1 .csv file and 0 sequence files) is ready for submission.',
+			`Please confirm that your selection (1 .csv file and 0 sequence files) is ready for submission for study ${organizationName}.`,
 		);
 	});
 
 	it('mentions both the CSV and tar file counts for a CSV + tar submission', () => {
 		const state = { oneCsv: [csvFile], oneOrMoreTar: [tarFile, tarFile], readyToUpload: true };
+		const organizationName = csvFile.name.split('.')[0].toUpperCase();
 		expect(getConfirmSubmissionMessage(state)).toBe(
-			'Please confirm that your selection (1 .csv file and 2 sequence files) is ready for submission.',
+			`Please confirm that your selection (1 .csv file and 2 sequence files) is ready for submission for study ${organizationName}.`,
 		);
 	});
 
 	it('falls back to the generic message for tar-only files when there is no previous submission', () => {
 		const state = { oneCsv: [], oneOrMoreTar: [tarFile], readyToUpload: true };
 		expect(getConfirmSubmissionMessage(state)).toBe(
-			'Please confirm that your selection (0 .csv files and 1 sequence file) is ready for submission.',
+			`Please confirm that your selection (0 .csv files and 1 sequence file) is ready for submission.`,
 		);
 	});
 
 	it('falls back to the generic message for tar-only files when the previous submission is not VALID', () => {
 		const state = { oneCsv: [], oneOrMoreTar: [tarFile], readyToUpload: true };
 		const previousSubmission = activeSubmission('ORGA', 'OPEN');
-		expect(getConfirmSubmissionMessage(state, previousSubmission)).toBe(
-			'Please confirm that your selection (0 .csv files and 1 sequence file) is ready for submission.',
+		expect(getConfirmSubmissionMessage(state)).toBe(
+			`Please confirm that your selection (0 .csv files and 1 sequence file) is ready for submission.`,
 		);
 	});
 
@@ -119,7 +121,7 @@ describe('getConfirmSubmissionMessage', () => {
 		const state = { oneCsv: [], oneOrMoreTar: [tarFile], readyToUpload: true };
 		const previousSubmission = activeSubmission('ORGA', 'VALID');
 		expect(getConfirmSubmissionMessage(state, previousSubmission)).toBe(
-			`Please confirm you want to add 1 sequence file to your active submission ID ${previousSubmission.id}.`,
+			`Please confirm you want to add 1 sequence file to your active submission ID ${previousSubmission.id} for study ${previousSubmission.organization}.`,
 		);
 	});
 
@@ -127,7 +129,7 @@ describe('getConfirmSubmissionMessage', () => {
 		const state = { oneCsv: [], oneOrMoreTar: [tarFile, tarFile], readyToUpload: true };
 		const previousSubmission = activeSubmission('ORGA', 'VALID');
 		expect(getConfirmSubmissionMessage(state, previousSubmission)).toBe(
-			`Please confirm you want to add 2 sequence files to your active submission ID ${previousSubmission.id}.`,
+			`Please confirm you want to add 2 sequence files to your active submission ID ${previousSubmission.id} for study ${previousSubmission.organization}.`,
 		);
 	});
 });

--- a/components/pages/submission/Environmental/NewSubmissions/validationHelpers.test.js
+++ b/components/pages/submission/Environmental/NewSubmissions/validationHelpers.test.js
@@ -22,7 +22,8 @@
 const {
 	buildFormData,
 	getConfirmSubmissionMessage,
-	getTarOnlyEligibility,
+	isSubmissionReadyForUpload,
+	isTarOnlySubmissionEligible,
 	validationParameters,
 	validationReducer,
 } = require('./validationHelpers');
@@ -68,20 +69,52 @@ describe('validationReducer - is ready', () => {
 	});
 });
 
-describe('getTarOnlyEligibility', () => {
+describe('isTarOnlySubmissionEligible', () => {
 	it('is false when there is no previous submission', () => {
-		expect(getTarOnlyEligibility(undefined)).toBe(false);
+		expect(isTarOnlySubmissionEligible(undefined)).toBe(false);
 	});
 
 	it.each(['OPEN', 'VALIDATING', 'INVALID', 'CLOSED', 'COMMITTING', 'COMMITTED'])(
 		'is false when the previous submission has status %s',
 		(status) => {
-			expect(getTarOnlyEligibility(activeSubmission('ORGA', status))).toBe(false);
+			expect(isTarOnlySubmissionEligible(activeSubmission('ORGA', status))).toBe(false);
 		},
 	);
 
 	it('is true when the previous submission has status VALID', () => {
-		expect(getTarOnlyEligibility(activeSubmission('ORGA', 'VALID'))).toBe(true);
+		expect(isTarOnlySubmissionEligible(activeSubmission('ORGA', 'VALID'))).toBe(true);
+	});
+});
+
+describe('isSubmissionReadyForUpload', () => {
+	it('is true when there is exactly one CSV file', () => {
+		expect(
+			isSubmissionReadyForUpload({
+				oneCsv: [csvFile],
+				oneOrMoreTar: [],
+				isTarOnlySubmissionEligible: false,
+			}),
+		).toBe(true);
+	});
+
+	it('is true for tar-only uploads when eligible', () => {
+		expect(
+			isSubmissionReadyForUpload({
+				oneCsv: [],
+				oneOrMoreTar: [tarFile],
+				isTarOnlySubmissionEligible: true,
+			}),
+		).toBe(true);
+	});
+
+	it('is false for tar-only uploads when not eligible', () => {
+		expect(
+			isSubmissionReadyForUpload({
+				oneCsv: [],
+				oneOrMoreTar: [tarFile],
+				isTarOnlySubmissionEligible: false,
+			}),
+		).toBe(false);
 	});
 });
 

--- a/components/pages/submission/Environmental/NewSubmissions/validationHelpers.test.js
+++ b/components/pages/submission/Environmental/NewSubmissions/validationHelpers.test.js
@@ -159,7 +159,6 @@ describe('getConfirmSubmissionMessage', () => {
 
 	it('falls back to the generic message for tar-only files when the previous submission is not VALID', () => {
 		const state = { oneCsv: [], oneOrMoreTar: [tarFile], readyToUpload: true };
-		const previousSubmission = activeSubmission('ORGA', 'OPEN');
 		expect(getConfirmSubmissionMessage(state)).toBe(
 			`Please confirm that your selection (0 .csv files and 1 sequence file) is ready for submission.`,
 		);

--- a/components/pages/submission/Environmental/NewSubmissions/validationHelpers.test.js
+++ b/components/pages/submission/Environmental/NewSubmissions/validationHelpers.test.js
@@ -1,0 +1,204 @@
+/*
+ *
+ * Copyright (c) 2026 The Ontario Institute for Cancer Research. All rights reserved
+ *
+ *  This program and the accompanying materials are made available under the terms of
+ *  the GNU Affero General Public License v3.0. You should have received a copy of the
+ *  GNU Affero General Public License along with this program.
+ *   If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ *  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ *  SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ *  TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ *  OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ *  IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+const {
+	buildFormData,
+	getActiveSubmissionStatus,
+	getConfirmSubmissionMessage,
+	getTarOnlyEligibility,
+	validationParameters,
+	validationReducer,
+} = require('./validationHelpers');
+
+// Plain objects used only where the reducer/eligibility logic inspects `.name` (no FormData involved)
+const csvFile = { name: 'ORG.csv' };
+const tarFile = { name: 'sample1.tar.xz' };
+
+// Real File instances for buildFormData tests, since Node's FormData stringifies plain objects
+const buildCsvFile = () => new File(['content'], 'ORG.csv');
+const buildTarFile = () => {
+	const file = new File(['content'], 'sample1.tar.xz');
+	file.md5 = 'abc123';
+	return file;
+};
+
+const activeSubmission = (organization, status = 'VALID') => ({ id: 1, organization, status });
+
+describe('validationReducer - is ready', () => {
+	it('is ready with exactly one CSV and no tar files', () => {
+		const state = { oneCsv: [csvFile], oneOrMoreTar: [], readyToUpload: false };
+		expect(validationReducer(state, { type: 'is ready' }).readyToUpload).toBe(true);
+	});
+
+	it('is ready with one CSV and one or more tar files', () => {
+		const state = { oneCsv: [csvFile], oneOrMoreTar: [tarFile], readyToUpload: false };
+		expect(validationReducer(state, { type: 'is ready' }).readyToUpload).toBe(true);
+	});
+
+	it('is ready with tar file(s) only and no CSV', () => {
+		const state = { oneCsv: [], oneOrMoreTar: [tarFile], readyToUpload: false };
+		expect(validationReducer(state, { type: 'is ready' }).readyToUpload).toBe(true);
+	});
+
+	it('is not ready with no files at all', () => {
+		const state = { oneCsv: [], oneOrMoreTar: [], readyToUpload: false };
+		expect(validationReducer(state, { type: 'is ready' }).readyToUpload).toBe(false);
+	});
+
+	it('resets to the initial state on clear all', () => {
+		const state = { oneCsv: [csvFile], oneOrMoreTar: [tarFile], readyToUpload: true };
+		expect(validationReducer(state, { type: 'clear all' })).toEqual(validationParameters);
+	});
+});
+
+describe('getTarOnlyEligibility', () => {
+	it('is not-applicable when a CSV is present', () => {
+		const state = { oneCsv: [csvFile], oneOrMoreTar: [tarFile], readyToUpload: true };
+		expect(getTarOnlyEligibility(state, { status: 'done', matches: [] }).status).toBe('not-applicable');
+	});
+
+	it('is not-applicable when there are no tar files', () => {
+		const state = { oneCsv: [], oneOrMoreTar: [], readyToUpload: false };
+		expect(getTarOnlyEligibility(state, { status: 'done', matches: [] }).status).toBe('not-applicable');
+	});
+
+	it('is checking while the active-submission lookup is still loading', () => {
+		const state = { oneCsv: [], oneOrMoreTar: [tarFile], readyToUpload: true };
+		expect(getTarOnlyEligibility(state, { status: 'loading', matches: [] }).status).toBe('checking');
+	});
+
+	it('is no-active-submission when the lookup found nothing', () => {
+		const state = { oneCsv: [], oneOrMoreTar: [tarFile], readyToUpload: true };
+		expect(getTarOnlyEligibility(state, { status: 'done', matches: [] }).status).toBe('no-active-submission');
+	});
+
+	it('uses the last match when more than one is found (should not occur in practice)', () => {
+		const state = { oneCsv: [], oneOrMoreTar: [tarFile], readyToUpload: true };
+		const lookup = { status: 'done', matches: [activeSubmission('ORGA'), activeSubmission('ORGB')] };
+		expect(getTarOnlyEligibility(state, lookup)).toEqual({ status: 'ready', organization: 'ORGB' });
+	});
+
+	it.each(['OPEN', 'VALIDATING', 'INVALID', 'CLOSED', 'COMMITTING', 'COMMITTED'])(
+		'is submission-not-valid when the single match has status %s',
+		(status) => {
+			const state = { oneCsv: [], oneOrMoreTar: [tarFile], readyToUpload: true };
+			const lookup = { status: 'done', matches: [activeSubmission('ORGA', status)] };
+			expect(getTarOnlyEligibility(state, lookup).status).toBe('submission-not-valid');
+		},
+	);
+
+	it('is ready with the found organization when exactly one match is found', () => {
+		const state = { oneCsv: [], oneOrMoreTar: [tarFile], readyToUpload: true };
+		const lookup = { status: 'done', matches: [activeSubmission('ORGA')] };
+		expect(getTarOnlyEligibility(state, lookup)).toEqual({ status: 'ready', organization: 'ORGA' });
+	});
+});
+
+describe('getActiveSubmissionStatus', () => {
+	it('is checking while the lookup is still loading', () => {
+		expect(getActiveSubmissionStatus({ status: 'loading', matches: [] }).status).toBe('checking');
+	});
+
+	it('is none when the lookup found nothing', () => {
+		expect(getActiveSubmissionStatus({ status: 'done', matches: [] }).status).toBe('none');
+	});
+
+	it('is not-valid when the found submission is not VALID', () => {
+		const lookup = { status: 'done', matches: [activeSubmission('ORGA', 'OPEN')] };
+		expect(getActiveSubmissionStatus(lookup).status).toBe('not-valid');
+	});
+
+	it('is valid with the organization and submissionId when the found submission is VALID', () => {
+		const lookup = { status: 'done', matches: [activeSubmission('ORGA')] };
+		expect(getActiveSubmissionStatus(lookup)).toEqual({ status: 'valid', organization: 'ORGA', submissionId: 1 });
+	});
+
+	it('uses the last match when more than one is found (should not occur in practice)', () => {
+		const lookup = { status: 'done', matches: [activeSubmission('ORGA'), activeSubmission('ORGB')] };
+		expect(getActiveSubmissionStatus(lookup)).toEqual({ status: 'valid', organization: 'ORGB', submissionId: 1 });
+	});
+});
+
+describe('getConfirmSubmissionMessage', () => {
+	it('mentions the sequence file count (0) when there are no tar files', () => {
+		const state = { oneCsv: [csvFile], oneOrMoreTar: [], readyToUpload: true };
+		expect(getConfirmSubmissionMessage(state)).toBe(
+			'Please confirm that your selection (1 .csv file and 0 sequence files) is ready for submission.',
+		);
+	});
+
+	it('mentions the tar file count when adding tar files to an active submission (no CSV)', () => {
+		const state = { oneCsv: [], oneOrMoreTar: [tarFile], readyToUpload: true };
+		expect(getConfirmSubmissionMessage(state)).toBe(
+			'Please confirm you want to add 1 sequence file to your active submission.',
+		);
+	});
+
+	it('pluralizes the tar file count when adding more than one tar file (no CSV)', () => {
+		const state = { oneCsv: [], oneOrMoreTar: [tarFile, tarFile], readyToUpload: true };
+		expect(getConfirmSubmissionMessage(state)).toBe(
+			'Please confirm you want to add 2 sequence files to your active submission.',
+		);
+	});
+
+	it('mentions both the CSV and tar file counts for a CSV + tar submission', () => {
+		const state = { oneCsv: [csvFile], oneOrMoreTar: [tarFile, tarFile], readyToUpload: true };
+		expect(getConfirmSubmissionMessage(state)).toBe(
+			'Please confirm that your selection (1 .csv file and 2 sequence files) is ready for submission.',
+		);
+	});
+});
+
+describe('buildFormData', () => {
+	it('includes the CSV file when one is provided', () => {
+		const csvFile = buildCsvFile();
+		const formData = buildFormData('ORG', csvFile, []);
+		expect(formData.get('submissionFile')).toBe(csvFile);
+		expect(formData.get('organization')).toBe('ORG');
+		expect(formData.has('sequencingMetadata')).toBe(false);
+	});
+
+	it('omits the CSV field entirely for a tar-only (CSV-less) submission', () => {
+		const tarFileWithMd5 = buildTarFile();
+		const formData = buildFormData('ORG', undefined, [tarFileWithMd5]);
+		expect(formData.has('submissionFile')).toBe(false);
+		expect(formData.get('organization')).toBe('ORG');
+
+		const sequencingMetadata = JSON.parse(formData.get('sequencingMetadata'));
+		expect(sequencingMetadata).toEqual([
+			{
+				fileName: tarFileWithMd5.name,
+				fileSize: tarFileWithMd5.size,
+				fileMd5sum: tarFileWithMd5.md5,
+				fileAccess: 'open',
+				fileType: 'TAR',
+			},
+		]);
+	});
+
+	it('appends sequencingMetadata for tar files alongside a CSV', () => {
+		const csvFile = buildCsvFile();
+		const tarFileWithMd5 = buildTarFile();
+		const formData = buildFormData('ORG', csvFile, [tarFileWithMd5]);
+		expect(formData.get('submissionFile')).toBe(csvFile);
+		expect(formData.has('sequencingMetadata')).toBe(true);
+	});
+});

--- a/components/pages/submission/Environmental/NewSubmissions/validationHelpers.test.js
+++ b/components/pages/submission/Environmental/NewSubmissions/validationHelpers.test.js
@@ -21,7 +21,6 @@
 
 const {
 	buildFormData,
-	getActiveSubmissionStatus,
 	getConfirmSubmissionMessage,
 	getTarOnlyEligibility,
 	validationParameters,
@@ -70,70 +69,19 @@ describe('validationReducer - is ready', () => {
 });
 
 describe('getTarOnlyEligibility', () => {
-	it('is not-applicable when a CSV is present', () => {
-		const state = { oneCsv: [csvFile], oneOrMoreTar: [tarFile], readyToUpload: true };
-		expect(getTarOnlyEligibility(state, { status: 'done', matches: [] }).status).toBe('not-applicable');
-	});
-
-	it('is not-applicable when there are no tar files', () => {
-		const state = { oneCsv: [], oneOrMoreTar: [], readyToUpload: false };
-		expect(getTarOnlyEligibility(state, { status: 'done', matches: [] }).status).toBe('not-applicable');
-	});
-
-	it('is checking while the active-submission lookup is still loading', () => {
-		const state = { oneCsv: [], oneOrMoreTar: [tarFile], readyToUpload: true };
-		expect(getTarOnlyEligibility(state, { status: 'loading', matches: [] }).status).toBe('checking');
-	});
-
-	it('is no-active-submission when the lookup found nothing', () => {
-		const state = { oneCsv: [], oneOrMoreTar: [tarFile], readyToUpload: true };
-		expect(getTarOnlyEligibility(state, { status: 'done', matches: [] }).status).toBe('no-active-submission');
-	});
-
-	it('uses the last match when more than one is found (should not occur in practice)', () => {
-		const state = { oneCsv: [], oneOrMoreTar: [tarFile], readyToUpload: true };
-		const lookup = { status: 'done', matches: [activeSubmission('ORGA'), activeSubmission('ORGB')] };
-		expect(getTarOnlyEligibility(state, lookup)).toEqual({ status: 'ready', organization: 'ORGB' });
+	it('is false when there is no previous submission', () => {
+		expect(getTarOnlyEligibility(undefined)).toBe(false);
 	});
 
 	it.each(['OPEN', 'VALIDATING', 'INVALID', 'CLOSED', 'COMMITTING', 'COMMITTED'])(
-		'is submission-not-valid when the single match has status %s',
+		'is false when the previous submission has status %s',
 		(status) => {
-			const state = { oneCsv: [], oneOrMoreTar: [tarFile], readyToUpload: true };
-			const lookup = { status: 'done', matches: [activeSubmission('ORGA', status)] };
-			expect(getTarOnlyEligibility(state, lookup).status).toBe('submission-not-valid');
+			expect(getTarOnlyEligibility(activeSubmission('ORGA', status))).toBe(false);
 		},
 	);
 
-	it('is ready with the found organization when exactly one match is found', () => {
-		const state = { oneCsv: [], oneOrMoreTar: [tarFile], readyToUpload: true };
-		const lookup = { status: 'done', matches: [activeSubmission('ORGA')] };
-		expect(getTarOnlyEligibility(state, lookup)).toEqual({ status: 'ready', organization: 'ORGA' });
-	});
-});
-
-describe('getActiveSubmissionStatus', () => {
-	it('is checking while the lookup is still loading', () => {
-		expect(getActiveSubmissionStatus({ status: 'loading', matches: [] }).status).toBe('checking');
-	});
-
-	it('is none when the lookup found nothing', () => {
-		expect(getActiveSubmissionStatus({ status: 'done', matches: [] }).status).toBe('none');
-	});
-
-	it('is not-valid when the found submission is not VALID', () => {
-		const lookup = { status: 'done', matches: [activeSubmission('ORGA', 'OPEN')] };
-		expect(getActiveSubmissionStatus(lookup).status).toBe('not-valid');
-	});
-
-	it('is valid with the organization and submissionId when the found submission is VALID', () => {
-		const lookup = { status: 'done', matches: [activeSubmission('ORGA')] };
-		expect(getActiveSubmissionStatus(lookup)).toEqual({ status: 'valid', organization: 'ORGA', submissionId: 1 });
-	});
-
-	it('uses the last match when more than one is found (should not occur in practice)', () => {
-		const lookup = { status: 'done', matches: [activeSubmission('ORGA'), activeSubmission('ORGB')] };
-		expect(getActiveSubmissionStatus(lookup)).toEqual({ status: 'valid', organization: 'ORGB', submissionId: 1 });
+	it('is true when the previous submission has status VALID', () => {
+		expect(getTarOnlyEligibility(activeSubmission('ORGA', 'VALID'))).toBe(true);
 	});
 });
 
@@ -145,24 +93,41 @@ describe('getConfirmSubmissionMessage', () => {
 		);
 	});
 
-	it('mentions the tar file count when adding tar files to an active submission (no CSV)', () => {
-		const state = { oneCsv: [], oneOrMoreTar: [tarFile], readyToUpload: true };
-		expect(getConfirmSubmissionMessage(state)).toBe(
-			'Please confirm you want to add 1 sequence file to your active submission.',
-		);
-	});
-
-	it('pluralizes the tar file count when adding more than one tar file (no CSV)', () => {
-		const state = { oneCsv: [], oneOrMoreTar: [tarFile, tarFile], readyToUpload: true };
-		expect(getConfirmSubmissionMessage(state)).toBe(
-			'Please confirm you want to add 2 sequence files to your active submission.',
-		);
-	});
-
 	it('mentions both the CSV and tar file counts for a CSV + tar submission', () => {
 		const state = { oneCsv: [csvFile], oneOrMoreTar: [tarFile, tarFile], readyToUpload: true };
 		expect(getConfirmSubmissionMessage(state)).toBe(
 			'Please confirm that your selection (1 .csv file and 2 sequence files) is ready for submission.',
+		);
+	});
+
+	it('falls back to the generic message for tar-only files when there is no previous submission', () => {
+		const state = { oneCsv: [], oneOrMoreTar: [tarFile], readyToUpload: true };
+		expect(getConfirmSubmissionMessage(state)).toBe(
+			'Please confirm that your selection (0 .csv files and 1 sequence file) is ready for submission.',
+		);
+	});
+
+	it('falls back to the generic message for tar-only files when the previous submission is not VALID', () => {
+		const state = { oneCsv: [], oneOrMoreTar: [tarFile], readyToUpload: true };
+		const previousSubmission = activeSubmission('ORGA', 'OPEN');
+		expect(getConfirmSubmissionMessage(state, previousSubmission)).toBe(
+			'Please confirm that your selection (0 .csv files and 1 sequence file) is ready for submission.',
+		);
+	});
+
+	it('mentions the active submission id when adding tar files to a VALID previous submission (no CSV)', () => {
+		const state = { oneCsv: [], oneOrMoreTar: [tarFile], readyToUpload: true };
+		const previousSubmission = activeSubmission('ORGA', 'VALID');
+		expect(getConfirmSubmissionMessage(state, previousSubmission)).toBe(
+			`Please confirm you want to add 1 sequence file to your active submission ID ${previousSubmission.id}.`,
+		);
+	});
+
+	it('pluralizes the tar file count when adding more than one tar file to a VALID previous submission', () => {
+		const state = { oneCsv: [], oneOrMoreTar: [tarFile, tarFile], readyToUpload: true };
+		const previousSubmission = activeSubmission('ORGA', 'VALID');
+		expect(getConfirmSubmissionMessage(state, previousSubmission)).toBe(
+			`Please confirm you want to add 2 sequence files to your active submission ID ${previousSubmission.id}.`,
 		);
 	});
 });

--- a/components/pages/submission/Environmental/NewSubmissions/validationHelpers.ts
+++ b/components/pages/submission/Environmental/NewSubmissions/validationHelpers.ts
@@ -22,8 +22,15 @@
 import { Dispatch } from 'react';
 
 import type { SubmissionSummary } from '#global/hooks/useEnvironmentalData';
+import type { SubmissionManifest } from '#global/utils/fileManifest';
 
-import { acceptedFileExtensions, ValidationAction, ValidationParameters, type SubmissionFile } from './types';
+import {
+	acceptedFileExtensions,
+	type BatchError,
+	ValidationAction,
+	ValidationParameters,
+	type SubmissionFile,
+} from './types';
 
 export const validationParameters = {
 	oneCsv: [],
@@ -75,8 +82,18 @@ export const buildFormData = (
 	return formData;
 };
 
-const overwiteIfExists = (existingFiles: SubmissionFile[], file: SubmissionFile) =>
+const overwriteIfExists = (existingFiles: SubmissionFile[], file: SubmissionFile) =>
 	existingFiles.filter((old) => old.name !== file.name).concat(file);
+
+export const isSubmissionReadyForUpload = ({
+	oneCsv,
+	oneOrMoreTar,
+	isTarOnlySubmissionEligible,
+}: {
+	oneCsv: SubmissionFile[];
+	oneOrMoreTar: SubmissionFile[];
+	isTarOnlySubmissionEligible: boolean;
+}): boolean => oneCsv.length === 1 || (oneOrMoreTar.length > 0 && isTarOnlySubmissionEligible);
 
 export const validationReducer = (state: ValidationParameters, action: ValidationAction): ValidationParameters => {
 	switch (action.type) {
@@ -99,7 +116,7 @@ export const validationReducer = (state: ValidationParameters, action: Validatio
 		}
 
 		case 'add tar.xz': {
-			const oneOrMoreTar = overwiteIfExists(state.oneOrMoreTar, action.file);
+			const oneOrMoreTar = overwriteIfExists(state.oneOrMoreTar, action.file);
 			return {
 				...state,
 				oneOrMoreTar,
@@ -143,15 +160,49 @@ export const getFileExtension = (file: SubmissionFile | string = ''): string => 
 		.join('.');
 };
 
-export const minFiles = ({ oneCsv, oneOrMoreTar }: ValidationParameters): boolean =>
+// Returns true if any files are present
+export const hasFiles = ({ oneCsv, oneOrMoreTar }: ValidationParameters): boolean =>
 	oneCsv.length > 0 || oneOrMoreTar.length > 0;
 
-export const getTarOnlyEligibility = (previousSubmission: SubmissionSummary | undefined) => {
-	if (previousSubmission?.status === 'VALID') {
-		return true;
-	}
+// Returns true if csv-less submisison is eligible
+export const isTarOnlySubmissionEligible = (previousSubmission: SubmissionSummary | undefined): boolean => {
+	return !!(previousSubmission && previousSubmission.status === 'VALID');
+};
 
-	return false;
+// Returns true if a CSV is required and is missing.
+// Checks the previousSubmission to see if the submission is eligible for a tar-only submission.
+// If it is, then a CSV is not required.
+export const isCsvRequiredButMissing = ({
+	oneCsv,
+	isTarOnlySubmissionEligible,
+}: {
+	oneCsv: SubmissionFile[];
+	isTarOnlySubmissionEligible: boolean;
+}): boolean => !isTarOnlySubmissionEligible && oneCsv.length !== 1;
+
+// Returns true if there are submission blocking issues
+export const hasSubmissionBlockingIssues = ({
+	uploadError,
+	filesSubmissionInstructions,
+	isCsvRequiredButMissing,
+}: {
+	uploadError: BatchError[];
+	filesSubmissionInstructions: SubmissionManifest[];
+	isCsvRequiredButMissing: boolean;
+}) => {
+	return uploadError.length > 0 || filesSubmissionInstructions.length > 0 || isCsvRequiredButMissing;
+};
+
+// This function returns true when the "Submit" button should be enabled.
+// It makes sure the button is enabled only when the submission is ready to upload.
+export const shouldEnableSubmitButton = ({
+	isSubmissionReadyForUpload,
+	hasSubmissionBlockingIssues,
+}: {
+	isSubmissionReadyForUpload: boolean;
+	hasSubmissionBlockingIssues: boolean;
+}): boolean => {
+	return isSubmissionReadyForUpload && !hasSubmissionBlockingIssues;
 };
 
 const pluralize = (count: number, noun: string): string => `${count} ${noun}${count === 1 ? '' : 's'}`;

--- a/components/pages/submission/Environmental/NewSubmissions/validationHelpers.ts
+++ b/components/pages/submission/Environmental/NewSubmissions/validationHelpers.ts
@@ -146,8 +146,8 @@ export const getFileExtension = (file: SubmissionFile | string = ''): string => 
 export const minFiles = ({ oneCsv, oneOrMoreTar }: ValidationParameters): boolean =>
 	oneCsv.length > 0 || oneOrMoreTar.length > 0;
 
-export const getTarOnlyEligibility = (previouseSubmission: SubmissionSummary | undefined) => {
-	if (previouseSubmission?.status === 'VALID') {
+export const getTarOnlyEligibility = (previousSubmission: SubmissionSummary | undefined) => {
+	if (previousSubmission?.status === 'VALID') {
 		return true;
 	}
 

--- a/components/pages/submission/Environmental/NewSubmissions/validationHelpers.ts
+++ b/components/pages/submission/Environmental/NewSubmissions/validationHelpers.ts
@@ -168,13 +168,13 @@ export const getConfirmSubmissionMessage = (
 		return `Please confirm you want to add ${pluralize(
 			oneOrMoreTar.length,
 			'sequence file',
-		)} to your active submission ID ${previousSubmission.id}.`;
+		)} to your active submission ID ${previousSubmission.id} for study ${previousSubmission.organization}.`;
 	}
 
 	return `Please confirm that your selection (${pluralize(oneCsv.length, '.csv file')} and ${pluralize(
 		oneOrMoreTar.length,
 		'sequence file',
-	)}) is ready for submission.`;
+	)}) is ready for submission${oneCsv[0] ? ` for study ${oneCsv[0].name.split('.')[0].toUpperCase()}` : ''}.`;
 };
 
 export const validator =

--- a/components/pages/submission/Environmental/NewSubmissions/validationHelpers.ts
+++ b/components/pages/submission/Environmental/NewSubmissions/validationHelpers.ts
@@ -95,6 +95,12 @@ export const isSubmissionReadyForUpload = ({
 	isTarOnlySubmissionEligible: boolean;
 }): boolean => oneCsv.length === 1 || (oneOrMoreTar.length > 0 && isTarOnlySubmissionEligible);
 
+// Local readiness check used inside reducer before previous-submission context is available.
+export const isFileSelectionReadyForUpload = ({
+	oneCsv,
+	oneOrMoreTar,
+}: Pick<ValidationParameters, 'oneCsv' | 'oneOrMoreTar'>): boolean => oneCsv.length === 1 || oneOrMoreTar.length > 0;
+
 export const validationReducer = (state: ValidationParameters, action: ValidationAction): ValidationParameters => {
 	switch (action.type) {
 		case 'add csv': {
@@ -136,7 +142,7 @@ export const validationReducer = (state: ValidationParameters, action: Validatio
 		case 'is ready': {
 			return {
 				...state,
-				readyToUpload: state.oneCsv.length === 1 || state.oneOrMoreTar.length > 0,
+				readyToUpload: isFileSelectionReadyForUpload(state),
 			};
 		}
 

--- a/components/pages/submission/Environmental/NewSubmissions/validationHelpers.ts
+++ b/components/pages/submission/Environmental/NewSubmissions/validationHelpers.ts
@@ -21,26 +21,64 @@
 
 import { Dispatch } from 'react';
 
-import { 
-	acceptedFileExtensions, 
-	ValidationAction, 
-	ValidationParameters, 
-	type SubmissionFile,
-} from './types';
+import type { SubmissionSummary } from '#global/hooks/useEnvironmentalData';
+
+import { acceptedFileExtensions, ValidationAction, ValidationParameters, type SubmissionFile } from './types';
 
 export const validationParameters = {
 	oneCsv: [],
 	oneOrMoreTar: [],
-	readyToUpload: false, // there's at least one CSV
+	readyToUpload: false, // true when: exactly one CSV is present, or zero CSV + at least one tar.xz is present
+};
+
+// Constants for submit parms
+export const SubmitParams = {
+	ORGANIZATION: 'organization' as const,
+	ENTITY_NAME: 'entityName' as const,
+	SUBMISSION_FILE: 'submissionFile' as const,
+	SEQUENCING_METADATA: 'sequencingMetadata' as const,
+};
+
+// Constants for file metadata
+export const SequencingMetadataDefaults = {
+	FILE_ACCESS: 'open' as const,
+	FILE_TYPE: 'TAR' as const,
+};
+
+export const buildFormData = (
+	organizationName: string,
+	selectedCsv: SubmissionFile | undefined,
+	oneOrMoreTar: SubmissionFile[],
+) => {
+	const formData = new FormData();
+	formData.append(SubmitParams.ORGANIZATION, organizationName);
+	formData.append(SubmitParams.ENTITY_NAME, 'sample');
+
+	if (selectedCsv) {
+		formData.append(SubmitParams.SUBMISSION_FILE, selectedCsv);
+	}
+
+	if (oneOrMoreTar.length > 0) {
+		formData.append(
+			SubmitParams.SEQUENCING_METADATA,
+			JSON.stringify(
+				oneOrMoreTar.map((tarFile: SubmissionFile) => ({
+					fileName: tarFile.name,
+					fileSize: tarFile.size,
+					fileMd5sum: tarFile.md5,
+					fileAccess: SequencingMetadataDefaults.FILE_ACCESS,
+					fileType: SequencingMetadataDefaults.FILE_TYPE,
+				})),
+			),
+		);
+	}
+	return formData;
 };
 
 const overwiteIfExists = (existingFiles: SubmissionFile[], file: SubmissionFile) =>
 	existingFiles.filter((old) => old.name !== file.name).concat(file);
 
-export const validationReducer = (
-	state: ValidationParameters, 
-	action: ValidationAction,
-): ValidationParameters => {
+export const validationReducer = (state: ValidationParameters, action: ValidationAction): ValidationParameters => {
 	switch (action.type) {
 		case 'add csv': {
 			const oneCsv = [action.file];
@@ -70,9 +108,7 @@ export const validationReducer = (
 		}
 
 		case 'remove tar.xz': {
-			const oneOrMoreTar = state.oneOrMoreTar.filter(
-				(tarFile: SubmissionFile) => tarFile.name !== action.file,
-			);
+			const oneOrMoreTar = state.oneOrMoreTar.filter((tarFile: SubmissionFile) => tarFile.name !== action.file);
 			return {
 				...state,
 				oneOrMoreTar,
@@ -83,7 +119,7 @@ export const validationReducer = (
 		case 'is ready': {
 			return {
 				...state,
-				readyToUpload: state.oneCsv.length === 1 && state.oneOrMoreTar.length >= 0,
+				readyToUpload: state.oneCsv.length === 1 || state.oneOrMoreTar.length > 0,
 			};
 		}
 
@@ -102,16 +138,44 @@ export const getFileExtension = (file: SubmissionFile | string = ''): string => 
 	// get the compound extension (e.g., tar.xz) or a single part extension (e.g., csv)
 	return parsedFileName
 		.slice(
-			-(parsedFileName?.[parsedFileName.length - 1] === 
-			acceptedFileExtensions.TAR_XZ.split('.').pop()
-				? 2 
-				: 1),
+			-(parsedFileName?.[parsedFileName.length - 1] === acceptedFileExtensions.TAR_XZ.split('.').pop() ? 2 : 1),
 		)
 		.join('.');
 };
 
 export const minFiles = ({ oneCsv, oneOrMoreTar }: ValidationParameters): boolean =>
 	oneCsv.length > 0 || oneOrMoreTar.length > 0;
+
+export const getTarOnlyEligibility = (previouseSubmission: SubmissionSummary | undefined) => {
+	if (previouseSubmission?.status === 'VALID') {
+		return true;
+	}
+
+	return false;
+};
+
+const pluralize = (count: number, noun: string): string => `${count} ${noun}${count === 1 ? '' : 's'}`;
+
+/**
+ * Builds the confirmation message shown before submitting, naming how many files of each
+ * type are about to be submitted so the user can double-check their selection.
+ */
+export const getConfirmSubmissionMessage = (
+	{ oneCsv, oneOrMoreTar }: ValidationParameters,
+	previousSubmission?: SubmissionSummary,
+): string => {
+	if (oneCsv.length === 0 && oneOrMoreTar.length > 0 && previousSubmission?.status === 'VALID') {
+		return `Please confirm you want to add ${pluralize(
+			oneOrMoreTar.length,
+			'sequence file',
+		)} to your active submission ID ${previousSubmission.id}.`;
+	}
+
+	return `Please confirm that your selection (${pluralize(oneCsv.length, '.csv file')} and ${pluralize(
+		oneOrMoreTar.length,
+		'sequence file',
+	)}) is ready for submission.`;
+};
 
 export const validator =
 	(state: ValidationParameters, dispatch: Dispatch<ValidationAction>) =>

--- a/components/pages/submission/Environmental/PreviousSubmissions/types.ts
+++ b/components/pages/submission/Environmental/PreviousSubmissions/types.ts
@@ -19,10 +19,10 @@
  *
  */
 
-import { DataRecord } from '#global/hooks/useEnvironmentalData';
+import { type SubmissionSummary } from '#global/hooks/useEnvironmentalData';
 
 export type SubmissionPaginatedResponse = {
-	data: DataRecord[];
+	data: SubmissionSummary[];
 	first: boolean;
 	last: boolean;
 	page: number;

--- a/global/hooks/useEnvironmentalData/index.ts
+++ b/global/hooks/useEnvironmentalData/index.ts
@@ -240,12 +240,12 @@ const useEnvironmentalData = (origin: string) => {
 
 		return {
 			data: response.records,
-			first: response.pagination.currentPage === 1,
-			last: response.pagination.currentPage === response.pagination.totalPages,
-			page: response.pagination.currentPage,
-			size: response.records.length,
-			totalPages: response.pagination.totalPages,
-			totalRecords: response.pagination.totalRecords,
+			first: response.pagination?.currentPage === 1,
+			last: response.pagination?.currentPage === response.pagination?.totalPages,
+			page: response.pagination?.currentPage ?? 1,
+			size: response.records?.length ?? 0,
+			totalPages: response.pagination?.totalPages ?? 1,
+			totalRecords: response.pagination?.totalRecords ?? 0,
 		};
 	};
 

--- a/global/hooks/useEnvironmentalData/index.ts
+++ b/global/hooks/useEnvironmentalData/index.ts
@@ -355,7 +355,8 @@ const useEnvironmentalData = (origin: string) => {
 	const getActiveSubmission = async (
 		organization: string,
 		username?: string,
-	): Promise<Promise<SubmissionSummary | undefined>> => {
+		signal?: AbortSignal,
+	): Promise<SubmissionSummary | undefined> => {
 		const queryParams = new URLSearchParams({
 			organization,
 			pageSize: '1',
@@ -375,6 +376,7 @@ const useEnvironmentalData = (origin: string) => {
 				`?${queryParams.toString()}`,
 			),
 			method: 'GET',
+			signal,
 		});
 
 		if (responseActiveSubmission.records) {
@@ -482,7 +484,9 @@ const useEnvironmentalData = (origin: string) => {
 
 	/**
 	 * Submit files for processing as part of a Submission
-	 * If an Active Submission already exists it will be closed
+	 * If a CSV is included and an Active Submission already exists, it will be closed first.
+	 * If no CSV is included (sequencing files only), the Active Submission is left as-is so the
+	 * files are added to it instead of being replaced.
 	 * @param param0
 	 * @returns
 	 */
@@ -490,19 +494,22 @@ const useEnvironmentalData = (origin: string) => {
 		const organization = body.get('organization')?.toString();
 		if (!organization) throw new Error('Organization is required field');
 
-		const activeSubmission = await getActiveSubmission(organization, user?.email);
+		if (body.has('submissionFile')) {
+			// .csv file is included, so we need to check for an existing active Submission and close it first
+			const activeSubmission = await getActiveSubmission(organization, user?.email);
 
-		if (activeSubmission) {
-			// need to delete previous active Submission
-			await handleRequest({
-				url: urlJoin(
-					NEXT_PUBLIC_ENVIRONMENTAL_SUBMISSION_API_URL,
-					'submission',
-					activeSubmission.id.toString(),
-				),
-				method: 'DELETE',
-				body: body,
-			});
+			if (activeSubmission) {
+				// need to delete previous active Submission
+				await handleRequest({
+					url: urlJoin(
+						NEXT_PUBLIC_ENVIRONMENTAL_SUBMISSION_API_URL,
+						'submission',
+						activeSubmission.id.toString(),
+					),
+					method: 'DELETE',
+					body: body,
+				});
+			}
 		}
 
 		return handleRequest({

--- a/package-lock.json
+++ b/package-lock.json
@@ -122,7 +122,6 @@
 			"version": "7.20.12",
 			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.20.12.tgz",
 			"integrity": "sha512-XsMfHovsUYHFMdrIHkZphTN/2Hzzi78R08NuHfDBehym2VsPDL6Zn/JAD/JQdnRvbSsbQc4mVaU1m6JgtTEElg==",
-			"peer": true,
 			"dependencies": {
 				"@ampproject/remapping": "^2.1.0",
 				"@babel/code-frame": "^7.18.6",
@@ -805,6 +804,7 @@
 			"resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
 			"integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"@jridgewell/trace-mapping": "0.3.9"
 			},
@@ -817,6 +817,7 @@
 			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
 			"integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"@jridgewell/resolve-uri": "^3.0.3",
 				"@jridgewell/sourcemap-codec": "^1.4.10"
@@ -2005,6 +2006,7 @@
 			"resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
 			"integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"@jridgewell/gen-mapping": "^0.3.0",
 				"@jridgewell/trace-mapping": "^0.3.9"
@@ -2416,7 +2418,6 @@
 			"resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
 			"integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
 			"license": "MIT",
-			"peer": true,
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/popperjs"
@@ -2509,25 +2510,29 @@
 			"version": "1.0.9",
 			"resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
 			"integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/@tsconfig/node12": {
 			"version": "1.0.11",
 			"resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
 			"integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/@tsconfig/node14": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
 			"integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/@tsconfig/node16": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
 			"integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/@types/babel__core": {
 			"version": "7.20.0",
@@ -2586,6 +2591,7 @@
 			"resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.4.tgz",
 			"integrity": "sha512-9K4zoImiZc3HlIp6AVUDE4CWYx22a+lhSZMYNpbjW04+YF0KWj4pJXnEMjdnFTiQibFFmElcsasJXDbdI/EPhA==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"@types/eslint": "*",
 				"@types/estree": "*"
@@ -2595,7 +2601,8 @@
 			"version": "0.0.51",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
 			"integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/@types/graceful-fs": {
 			"version": "4.1.6",
@@ -2662,7 +2669,6 @@
 			"integrity": "sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"undici-types": "~6.21.0"
 			}
@@ -2831,7 +2837,6 @@
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.49.0.tgz",
 			"integrity": "sha512-veDlZN9mUhGqU31Qiv2qEp+XrJj5fgZpJ8PW30sHU+j/8/e5ruAhLaVDAeznS7A7i4ucb/s8IozpDtt9NqCkZg==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "5.49.0",
 				"@typescript-eslint/types": "5.49.0",
@@ -3016,6 +3021,7 @@
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",
 			"integrity": "sha512-ukBh14qFLjxTQNTXocdyksN5QdM28S1CxHt2rdskFyL+xFV7VremuBLVbmCePj+URalXBENx/9Lm7lnhihtCSw==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"@webassemblyjs/helper-numbers": "1.11.1",
 				"@webassemblyjs/helper-wasm-bytecode": "1.11.1"
@@ -3025,25 +3031,29 @@
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.1.tgz",
 			"integrity": "sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/@webassemblyjs/helper-api-error": {
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.1.tgz",
 			"integrity": "sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/@webassemblyjs/helper-buffer": {
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.1.tgz",
 			"integrity": "sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/@webassemblyjs/helper-numbers": {
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.1.tgz",
 			"integrity": "sha512-vDkbxiB8zfnPdNK9Rajcey5C0w+QJugEglN0of+kmO8l7lDb77AnlKYQF7aarZuCrv+l0UvqL+68gSDr3k9LPQ==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"@webassemblyjs/floating-point-hex-parser": "1.11.1",
 				"@webassemblyjs/helper-api-error": "1.11.1",
@@ -3054,13 +3064,15 @@
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.1.tgz",
 			"integrity": "sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/@webassemblyjs/helper-wasm-section": {
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.1.tgz",
 			"integrity": "sha512-10P9No29rYX1j7F3EVPX3JvGPQPae+AomuSTPiF9eBQeChHI6iqjMIwR9JmOJXwpnn/oVGDk7I5IlskuMwU/pg==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"@webassemblyjs/ast": "1.11.1",
 				"@webassemblyjs/helper-buffer": "1.11.1",
@@ -3073,6 +3085,7 @@
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.1.tgz",
 			"integrity": "sha512-hJ87QIPtAMKbFq6CGTkZYJivEwZDbQUgYd3qKSadTNOhVY7p+gfP6Sr0lLRVTaG1JjFj+r3YchoqRYxNH3M0GQ==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"@xtuc/ieee754": "^1.2.0"
 			}
@@ -3082,6 +3095,7 @@
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.1.tgz",
 			"integrity": "sha512-BJ2P0hNZ0u+Th1YZXJpzW6miwqQUGcIHT1G/sf72gLVD9DZ5AdYTqPNbHZh6K1M5VmKvFXwGSWZADz+qBWxeRw==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"@xtuc/long": "4.2.2"
 			}
@@ -3090,13 +3104,15 @@
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.1.tgz",
 			"integrity": "sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/@webassemblyjs/wasm-edit": {
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.1.tgz",
 			"integrity": "sha512-g+RsupUC1aTHfR8CDgnsVRVZFJqdkFHpsHMfJuWQzWU3tvnLC07UqHICfP+4XyL2tnr1amvl1Sdp06TnYCmVkA==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"@webassemblyjs/ast": "1.11.1",
 				"@webassemblyjs/helper-buffer": "1.11.1",
@@ -3113,6 +3129,7 @@
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.1.tgz",
 			"integrity": "sha512-F7QqKXwwNlMmsulj6+O7r4mmtAlCWfO/0HdgOxSklZfQcDu0TpLiD1mRt/zF25Bk59FIjEuGAIyn5ei4yMfLhA==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"@webassemblyjs/ast": "1.11.1",
 				"@webassemblyjs/helper-wasm-bytecode": "1.11.1",
@@ -3126,6 +3143,7 @@
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.1.tgz",
 			"integrity": "sha512-VqnkNqnZlU5EB64pp1l7hdm3hmQw7Vgqa0KF/KCNO9sIpI6Fk6brDEiX+iCOYrvMuBWDws0NkTOxYEb85XQHHw==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"@webassemblyjs/ast": "1.11.1",
 				"@webassemblyjs/helper-buffer": "1.11.1",
@@ -3138,6 +3156,7 @@
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.1.tgz",
 			"integrity": "sha512-rrBujw+dJu32gYB7/Lup6UhdkPx9S9SnobZzRVL7VcBH9Bt9bCBLEuX/YXOOtBsOZ4NQrRykKhffRWHvigQvOA==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"@webassemblyjs/ast": "1.11.1",
 				"@webassemblyjs/helper-api-error": "1.11.1",
@@ -3152,6 +3171,7 @@
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.11.1.tgz",
 			"integrity": "sha512-IQboUWM4eKzWW+N/jij2sRatKMh99QEelo3Eb2q0qXkvPRISAj8Qxtmw5itwqK+TTkBuUIE45AxYPToqPtL5gg==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"@webassemblyjs/ast": "1.11.1",
 				"@xtuc/long": "4.2.2"
@@ -3161,19 +3181,20 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
 			"integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/@xtuc/long": {
 			"version": "4.2.2",
 			"resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
 			"integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/acorn": {
 			"version": "8.8.1",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
 			"integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
-			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -3186,6 +3207,7 @@
 			"resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
 			"integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
 			"dev": true,
+			"peer": true,
 			"peerDependencies": {
 				"acorn": "^8"
 			}
@@ -3202,7 +3224,6 @@
 			"version": "6.12.6",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
 			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -3284,7 +3305,8 @@
 			"version": "4.1.3",
 			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
 			"integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/argparse": {
 			"version": "2.0.1",
@@ -3731,7 +3753,6 @@
 					"url": "https://tidelift.com/funding/github/npm/browserslist"
 				}
 			],
-			"peer": true,
 			"dependencies": {
 				"caniuse-lite": "^1.0.30001400",
 				"electron-to-chromium": "^1.4.251",
@@ -3882,6 +3903,7 @@
 			"resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
 			"integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">=6.0"
 			}
@@ -3992,7 +4014,8 @@
 			"version": "2.20.3",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
 			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/concat-map": {
 			"version": "0.0.1",
@@ -4181,7 +4204,8 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
 			"integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.6",
@@ -4343,6 +4367,7 @@
 			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
 			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">=0.3.1"
 			}
@@ -4582,7 +4607,8 @@
 			"version": "0.9.3",
 			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
 			"integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/es-object-atoms": {
 			"version": "1.1.1",
@@ -4657,7 +4683,6 @@
 			"version": "8.32.0",
 			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.32.0.tgz",
 			"integrity": "sha512-nETVXpnthqKPFyuY2FNjz/bEd6nbosRgKbkgS/y1C7LJop96gYHWpiguLecMHQ2XCPxn77DS0P+68WzG6vkZSQ==",
-			"peer": true,
 			"dependencies": {
 				"@eslint/eslintrc": "^1.4.1",
 				"@humanwhocodes/config-array": "^0.11.8",
@@ -4715,7 +4740,6 @@
 			"integrity": "sha512-/IGJ6+Dka158JnP5n5YFMOszjDWrXggGz1LaK/guZq9vZTmniaKlHcsscvkAhn9y4U+BU3JuUdYvtAMcv30y4A==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"eslint-config-prettier": "bin/cli.js"
 			},
@@ -5252,6 +5276,7 @@
 			"resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
 			"integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">=0.8.x"
 			}
@@ -5922,7 +5947,8 @@
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
 			"integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/globals": {
 			"version": "11.12.0",
@@ -6084,8 +6110,7 @@
 		"node_modules/highcharts": {
 			"version": "9.0.1",
 			"resolved": "https://registry.npmjs.org/highcharts/-/highcharts-9.0.1.tgz",
-			"integrity": "sha512-0UmcCz2RmFuqfT/Igu3h5sGnkeSqqZwfuYrTzJ/htptmJAo5SSxH62NFcTjVRk+3WstoBJmoXR0v5FVGQUzK5A==",
-			"peer": true
+			"integrity": "sha512-0UmcCz2RmFuqfT/Igu3h5sGnkeSqqZwfuYrTzJ/htptmJAo5SSxH62NFcTjVRk+3WstoBJmoXR0v5FVGQUzK5A=="
 		},
 		"node_modules/highcharts-react-official": {
 			"version": "3.1.0",
@@ -8498,7 +8523,6 @@
 			"resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
 			"integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 10.16.0"
 			}
@@ -8696,6 +8720,7 @@
 			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
 			"integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">=6.11.5"
 			}
@@ -9020,7 +9045,8 @@
 			"version": "1.3.6",
 			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
 			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/makeerror": {
 			"version": "1.0.12",
@@ -9182,7 +9208,8 @@
 			"version": "2.6.2",
 			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
 			"integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/next": {
 			"version": "12.3.7",
@@ -9706,7 +9733,6 @@
 			"integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"prettier": "bin/prettier.cjs"
 			},
@@ -9808,7 +9834,6 @@
 			"version": "15.7.2",
 			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
 			"integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-			"peer": true,
 			"dependencies": {
 				"loose-envify": "^1.4.0",
 				"object-assign": "^4.1.1",
@@ -9875,6 +9900,7 @@
 			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
 			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"safe-buffer": "^5.1.0"
 			}
@@ -9883,7 +9909,6 @@
 			"version": "17.0.2",
 			"resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
 			"integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
-			"peer": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1"
@@ -9930,7 +9955,6 @@
 			"version": "17.0.2",
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
 			"integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
-			"peer": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1",
@@ -10656,6 +10680,7 @@
 			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.1.tgz",
 			"integrity": "sha512-owoXEFjWRllis8/M1Q+Cw5k8ZH40e3zhp/ovX+Xr/vi1qj6QesbyXXViFbpNvWvPNAD62SutwEXavefrLJWj7w==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"randombytes": "^2.1.0"
 			}
@@ -11063,6 +11088,7 @@
 			"resolved": "https://registry.npmjs.org/terser/-/terser-5.16.1.tgz",
 			"integrity": "sha512-xvQfyfA1ayT0qdK47zskQgRZeWLoOQ8JQ6mIgRGVNwZKdQMU+5FkCBjmv4QjcrTzyZquRw2FVtlJSRUmMKQslw==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"@jridgewell/source-map": "^0.3.2",
 				"acorn": "^8.5.0",
@@ -11081,6 +11107,7 @@
 			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.6.tgz",
 			"integrity": "sha512-kfLFk+PoLUQIbLmB1+PZDMRSZS99Mp+/MHqDNmMA6tOItzRt+Npe3E+fsMs5mfcM0wCtrrdU387UnV+vnSffXQ==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"@jridgewell/trace-mapping": "^0.3.14",
 				"jest-worker": "^27.4.5",
@@ -11115,6 +11142,7 @@
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
 			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -11124,6 +11152,7 @@
 			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
 			"integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"@types/node": "*",
 				"merge-stream": "^2.0.0",
@@ -11138,6 +11167,7 @@
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
 			"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"has-flag": "^4.0.0"
 			},
@@ -11153,6 +11183,7 @@
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -11162,6 +11193,7 @@
 			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
 			"integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"buffer-from": "^1.0.0",
 				"source-map": "^0.6.0"
@@ -11291,6 +11323,7 @@
 			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
 			"integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">=0.4.0"
 			}
@@ -11395,7 +11428,6 @@
 			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -11529,7 +11561,8 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
 			"integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/v8-to-istanbul": {
 			"version": "9.0.1",
@@ -11572,6 +11605,7 @@
 			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
 			"integrity": "sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"glob-to-regexp": "^0.4.1",
 				"graceful-fs": "^4.1.2"
@@ -11633,6 +11667,7 @@
 			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
 			"integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">=10.13.0"
 			}
@@ -11894,6 +11929,7 @@
 			"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
 			"integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">=6"
 			}
@@ -11974,7 +12010,6 @@
 			"version": "7.20.12",
 			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.20.12.tgz",
 			"integrity": "sha512-XsMfHovsUYHFMdrIHkZphTN/2Hzzi78R08NuHfDBehym2VsPDL6Zn/JAD/JQdnRvbSsbQc4mVaU1m6JgtTEElg==",
-			"peer": true,
 			"requires": {
 				"@ampproject/remapping": "^2.1.0",
 				"@babel/code-frame": "^7.18.6",
@@ -12464,6 +12499,7 @@
 			"resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
 			"integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
 			"dev": true,
+			"peer": true,
 			"requires": {
 				"@jridgewell/trace-mapping": "0.3.9"
 			},
@@ -12473,6 +12509,7 @@
 					"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
 					"integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
 					"dev": true,
+					"peer": true,
 					"requires": {
 						"@jridgewell/resolve-uri": "^3.0.3",
 						"@jridgewell/sourcemap-codec": "^1.4.10"
@@ -13363,6 +13400,7 @@
 			"resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
 			"integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
 			"dev": true,
+			"peer": true,
 			"requires": {
 				"@jridgewell/gen-mapping": "^0.3.0",
 				"@jridgewell/trace-mapping": "^0.3.9"
@@ -13592,8 +13630,7 @@
 		"@popperjs/core": {
 			"version": "2.11.8",
 			"resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
-			"integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
-			"peer": true
+			"integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A=="
 		},
 		"@reach/component-component": {
 			"version": "0.17.0",
@@ -13659,25 +13696,29 @@
 			"version": "1.0.9",
 			"resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
 			"integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"@tsconfig/node12": {
 			"version": "1.0.11",
 			"resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
 			"integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"@tsconfig/node14": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
 			"integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"@tsconfig/node16": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
 			"integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"@types/babel__core": {
 			"version": "7.20.0",
@@ -13736,6 +13777,7 @@
 			"resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.4.tgz",
 			"integrity": "sha512-9K4zoImiZc3HlIp6AVUDE4CWYx22a+lhSZMYNpbjW04+YF0KWj4pJXnEMjdnFTiQibFFmElcsasJXDbdI/EPhA==",
 			"dev": true,
+			"peer": true,
 			"requires": {
 				"@types/eslint": "*",
 				"@types/estree": "*"
@@ -13745,7 +13787,8 @@
 			"version": "0.0.51",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
 			"integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"@types/graceful-fs": {
 			"version": "4.1.6",
@@ -13811,7 +13854,6 @@
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.14.1.tgz",
 			"integrity": "sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"undici-types": "~6.21.0"
 			}
@@ -13954,7 +13996,6 @@
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.49.0.tgz",
 			"integrity": "sha512-veDlZN9mUhGqU31Qiv2qEp+XrJj5fgZpJ8PW30sHU+j/8/e5ruAhLaVDAeznS7A7i4ucb/s8IozpDtt9NqCkZg==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"@typescript-eslint/scope-manager": "5.49.0",
 				"@typescript-eslint/types": "5.49.0",
@@ -14058,6 +14099,7 @@
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",
 			"integrity": "sha512-ukBh14qFLjxTQNTXocdyksN5QdM28S1CxHt2rdskFyL+xFV7VremuBLVbmCePj+URalXBENx/9Lm7lnhihtCSw==",
 			"dev": true,
+			"peer": true,
 			"requires": {
 				"@webassemblyjs/helper-numbers": "1.11.1",
 				"@webassemblyjs/helper-wasm-bytecode": "1.11.1"
@@ -14067,25 +14109,29 @@
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.1.tgz",
 			"integrity": "sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"@webassemblyjs/helper-api-error": {
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.1.tgz",
 			"integrity": "sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"@webassemblyjs/helper-buffer": {
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.1.tgz",
 			"integrity": "sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"@webassemblyjs/helper-numbers": {
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.1.tgz",
 			"integrity": "sha512-vDkbxiB8zfnPdNK9Rajcey5C0w+QJugEglN0of+kmO8l7lDb77AnlKYQF7aarZuCrv+l0UvqL+68gSDr3k9LPQ==",
 			"dev": true,
+			"peer": true,
 			"requires": {
 				"@webassemblyjs/floating-point-hex-parser": "1.11.1",
 				"@webassemblyjs/helper-api-error": "1.11.1",
@@ -14096,13 +14142,15 @@
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.1.tgz",
 			"integrity": "sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"@webassemblyjs/helper-wasm-section": {
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.1.tgz",
 			"integrity": "sha512-10P9No29rYX1j7F3EVPX3JvGPQPae+AomuSTPiF9eBQeChHI6iqjMIwR9JmOJXwpnn/oVGDk7I5IlskuMwU/pg==",
 			"dev": true,
+			"peer": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.11.1",
 				"@webassemblyjs/helper-buffer": "1.11.1",
@@ -14115,6 +14163,7 @@
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.1.tgz",
 			"integrity": "sha512-hJ87QIPtAMKbFq6CGTkZYJivEwZDbQUgYd3qKSadTNOhVY7p+gfP6Sr0lLRVTaG1JjFj+r3YchoqRYxNH3M0GQ==",
 			"dev": true,
+			"peer": true,
 			"requires": {
 				"@xtuc/ieee754": "^1.2.0"
 			}
@@ -14124,6 +14173,7 @@
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.1.tgz",
 			"integrity": "sha512-BJ2P0hNZ0u+Th1YZXJpzW6miwqQUGcIHT1G/sf72gLVD9DZ5AdYTqPNbHZh6K1M5VmKvFXwGSWZADz+qBWxeRw==",
 			"dev": true,
+			"peer": true,
 			"requires": {
 				"@xtuc/long": "4.2.2"
 			}
@@ -14132,13 +14182,15 @@
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.1.tgz",
 			"integrity": "sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"@webassemblyjs/wasm-edit": {
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.1.tgz",
 			"integrity": "sha512-g+RsupUC1aTHfR8CDgnsVRVZFJqdkFHpsHMfJuWQzWU3tvnLC07UqHICfP+4XyL2tnr1amvl1Sdp06TnYCmVkA==",
 			"dev": true,
+			"peer": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.11.1",
 				"@webassemblyjs/helper-buffer": "1.11.1",
@@ -14155,6 +14207,7 @@
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.1.tgz",
 			"integrity": "sha512-F7QqKXwwNlMmsulj6+O7r4mmtAlCWfO/0HdgOxSklZfQcDu0TpLiD1mRt/zF25Bk59FIjEuGAIyn5ei4yMfLhA==",
 			"dev": true,
+			"peer": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.11.1",
 				"@webassemblyjs/helper-wasm-bytecode": "1.11.1",
@@ -14168,6 +14221,7 @@
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.1.tgz",
 			"integrity": "sha512-VqnkNqnZlU5EB64pp1l7hdm3hmQw7Vgqa0KF/KCNO9sIpI6Fk6brDEiX+iCOYrvMuBWDws0NkTOxYEb85XQHHw==",
 			"dev": true,
+			"peer": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.11.1",
 				"@webassemblyjs/helper-buffer": "1.11.1",
@@ -14180,6 +14234,7 @@
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.1.tgz",
 			"integrity": "sha512-rrBujw+dJu32gYB7/Lup6UhdkPx9S9SnobZzRVL7VcBH9Bt9bCBLEuX/YXOOtBsOZ4NQrRykKhffRWHvigQvOA==",
 			"dev": true,
+			"peer": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.11.1",
 				"@webassemblyjs/helper-api-error": "1.11.1",
@@ -14194,6 +14249,7 @@
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.11.1.tgz",
 			"integrity": "sha512-IQboUWM4eKzWW+N/jij2sRatKMh99QEelo3Eb2q0qXkvPRISAj8Qxtmw5itwqK+TTkBuUIE45AxYPToqPtL5gg==",
 			"dev": true,
+			"peer": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.11.1",
 				"@xtuc/long": "4.2.2"
@@ -14203,25 +14259,27 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
 			"integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"@xtuc/long": {
 			"version": "4.2.2",
 			"resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
 			"integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"acorn": {
 			"version": "8.8.1",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
-			"integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
-			"peer": true
+			"integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA=="
 		},
 		"acorn-import-assertions": {
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
 			"integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
 			"dev": true,
+			"peer": true,
 			"requires": {}
 		},
 		"acorn-jsx": {
@@ -14234,7 +14292,6 @@
 			"version": "6.12.6",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
 			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-			"peer": true,
 			"requires": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -14270,7 +14327,8 @@
 			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
 		},
 		"ansi-styles": {
-			"version": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 			"requires": {
 				"color-convert": "^1.9.0"
@@ -14290,7 +14348,8 @@
 			"version": "4.1.3",
 			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
 			"integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"argparse": {
 			"version": "2.0.1",
@@ -14636,7 +14695,6 @@
 			"version": "4.21.4",
 			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
 			"integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
-			"peer": true,
 			"requires": {
 				"caniuse-lite": "^1.0.30001400",
 				"electron-to-chromium": "^1.4.251",
@@ -14740,7 +14798,8 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
 			"integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"cjs-module-lexer": {
 			"version": "1.2.2",
@@ -14834,7 +14893,8 @@
 			"version": "2.20.3",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
 			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"concat-map": {
 			"version": "0.0.1",
@@ -14975,7 +15035,8 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
 			"integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"cross-spawn": {
 			"version": "7.0.6",
@@ -15100,7 +15161,8 @@
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
 			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"diff-sequences": {
 			"version": "29.3.1",
@@ -15295,7 +15357,8 @@
 			"version": "0.9.3",
 			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
 			"integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"es-object-atoms": {
 			"version": "1.1.1",
@@ -15350,7 +15413,6 @@
 			"version": "8.32.0",
 			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.32.0.tgz",
 			"integrity": "sha512-nETVXpnthqKPFyuY2FNjz/bEd6nbosRgKbkgS/y1C7LJop96gYHWpiguLecMHQ2XCPxn77DS0P+68WzG6vkZSQ==",
-			"peer": true,
 			"requires": {
 				"@eslint/eslintrc": "^1.4.1",
 				"@humanwhocodes/config-array": "^0.11.8",
@@ -15518,7 +15580,6 @@
 			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.10.2.tgz",
 			"integrity": "sha512-/IGJ6+Dka158JnP5n5YFMOszjDWrXggGz1LaK/guZq9vZTmniaKlHcsscvkAhn9y4U+BU3JuUdYvtAMcv30y4A==",
 			"dev": true,
-			"peer": true,
 			"requires": {}
 		},
 		"eslint-import-resolver-babel-module": {
@@ -15773,7 +15834,8 @@
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
 			"integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"exit": {
 			"version": "0.1.2",
@@ -16266,7 +16328,8 @@
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
 			"integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"globals": {
 			"version": "11.12.0",
@@ -16370,8 +16433,7 @@
 		"highcharts": {
 			"version": "9.0.1",
 			"resolved": "https://registry.npmjs.org/highcharts/-/highcharts-9.0.1.tgz",
-			"integrity": "sha512-0UmcCz2RmFuqfT/Igu3h5sGnkeSqqZwfuYrTzJ/htptmJAo5SSxH62NFcTjVRk+3WstoBJmoXR0v5FVGQUzK5A==",
-			"peer": true
+			"integrity": "sha512-0UmcCz2RmFuqfT/Igu3h5sGnkeSqqZwfuYrTzJ/htptmJAo5SSxH62NFcTjVRk+3WstoBJmoXR0v5FVGQUzK5A=="
 		},
 		"highcharts-react-official": {
 			"version": "3.1.0",
@@ -18137,8 +18199,7 @@
 		"jsep": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
-			"integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
-			"peer": true
+			"integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw=="
 		},
 		"jsesc": {
 			"version": "2.5.2",
@@ -18302,7 +18363,8 @@
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
 			"integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"loaders.css": {
 			"version": "0.1.2",
@@ -18599,7 +18661,8 @@
 			"version": "1.3.6",
 			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
 			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"makeerror": {
 			"version": "1.0.12",
@@ -18715,7 +18778,8 @@
 			"version": "2.6.2",
 			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
 			"integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"next": {
 			"version": "12.3.7",
@@ -19069,8 +19133,7 @@
 			"version": "3.6.2",
 			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
 			"integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"prettier-linter-helpers": {
 			"version": "1.0.0",
@@ -19140,7 +19203,6 @@
 			"version": "15.7.2",
 			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
 			"integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-			"peer": true,
 			"requires": {
 				"loose-envify": "^1.4.0",
 				"object-assign": "^4.1.1",
@@ -19183,6 +19245,7 @@
 			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
 			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
 			"dev": true,
+			"peer": true,
 			"requires": {
 				"safe-buffer": "^5.1.0"
 			}
@@ -19191,7 +19254,6 @@
 			"version": "17.0.2",
 			"resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
 			"integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
-			"peer": true,
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1"
@@ -19224,7 +19286,6 @@
 			"version": "17.0.2",
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
 			"integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
-			"peer": true,
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1",
@@ -19782,6 +19843,7 @@
 			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.1.tgz",
 			"integrity": "sha512-owoXEFjWRllis8/M1Q+Cw5k8ZH40e3zhp/ovX+Xr/vi1qj6QesbyXXViFbpNvWvPNAD62SutwEXavefrLJWj7w==",
 			"dev": true,
+			"peer": true,
 			"requires": {
 				"randombytes": "^2.1.0"
 			}
@@ -20078,6 +20140,7 @@
 			"resolved": "https://registry.npmjs.org/terser/-/terser-5.16.1.tgz",
 			"integrity": "sha512-xvQfyfA1ayT0qdK47zskQgRZeWLoOQ8JQ6mIgRGVNwZKdQMU+5FkCBjmv4QjcrTzyZquRw2FVtlJSRUmMKQslw==",
 			"dev": true,
+			"peer": true,
 			"requires": {
 				"@jridgewell/source-map": "^0.3.2",
 				"acorn": "^8.5.0",
@@ -20089,13 +20152,15 @@
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
+					"dev": true,
+					"peer": true
 				},
 				"source-map-support": {
 					"version": "0.5.21",
 					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
 					"integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
 					"dev": true,
+					"peer": true,
 					"requires": {
 						"buffer-from": "^1.0.0",
 						"source-map": "^0.6.0"
@@ -20108,6 +20173,7 @@
 			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.6.tgz",
 			"integrity": "sha512-kfLFk+PoLUQIbLmB1+PZDMRSZS99Mp+/MHqDNmMA6tOItzRt+Npe3E+fsMs5mfcM0wCtrrdU387UnV+vnSffXQ==",
 			"dev": true,
+			"peer": true,
 			"requires": {
 				"@jridgewell/trace-mapping": "^0.3.14",
 				"jest-worker": "^27.4.5",
@@ -20120,13 +20186,15 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
 					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
+					"dev": true,
+					"peer": true
 				},
 				"jest-worker": {
 					"version": "27.5.1",
 					"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
 					"integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
 					"dev": true,
+					"peer": true,
 					"requires": {
 						"@types/node": "*",
 						"merge-stream": "^2.0.0",
@@ -20138,6 +20206,7 @@
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
 					"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
 					"dev": true,
+					"peer": true,
 					"requires": {
 						"has-flag": "^4.0.0"
 					}
@@ -20232,7 +20301,8 @@
 					"version": "8.2.0",
 					"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
 					"integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
-					"dev": true
+					"dev": true,
+					"peer": true
 				}
 			}
 		},
@@ -20307,8 +20377,7 @@
 			"version": "5.9.3",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
 			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"typescript-transform-paths": {
 			"version": "3.4.6",
@@ -20390,7 +20459,8 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
 			"integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"v8-to-istanbul": {
 			"version": "9.0.1",
@@ -20430,6 +20500,7 @@
 			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
 			"integrity": "sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==",
 			"dev": true,
+			"peer": true,
 			"requires": {
 				"glob-to-regexp": "^0.4.1",
 				"graceful-fs": "^4.1.2"
@@ -20472,7 +20543,8 @@
 			"version": "3.2.3",
 			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
 			"integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"whatwg-fetch": {
 			"version": "2.0.4",
@@ -20662,7 +20734,8 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
 			"integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"yocto-queue": {
 			"version": "0.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -122,6 +122,7 @@
 			"version": "7.20.12",
 			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.20.12.tgz",
 			"integrity": "sha512-XsMfHovsUYHFMdrIHkZphTN/2Hzzi78R08NuHfDBehym2VsPDL6Zn/JAD/JQdnRvbSsbQc4mVaU1m6JgtTEElg==",
+			"peer": true,
 			"dependencies": {
 				"@ampproject/remapping": "^2.1.0",
 				"@babel/code-frame": "^7.18.6",
@@ -804,7 +805,6 @@
 			"resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
 			"integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@jridgewell/trace-mapping": "0.3.9"
 			},
@@ -817,7 +817,6 @@
 			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
 			"integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@jridgewell/resolve-uri": "^3.0.3",
 				"@jridgewell/sourcemap-codec": "^1.4.10"
@@ -2006,7 +2005,6 @@
 			"resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
 			"integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@jridgewell/gen-mapping": "^0.3.0",
 				"@jridgewell/trace-mapping": "^0.3.9"
@@ -2418,6 +2416,7 @@
 			"resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
 			"integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
 			"license": "MIT",
+			"peer": true,
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/popperjs"
@@ -2510,29 +2509,25 @@
 			"version": "1.0.9",
 			"resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
 			"integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/@tsconfig/node12": {
 			"version": "1.0.11",
 			"resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
 			"integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/@tsconfig/node14": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
 			"integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/@tsconfig/node16": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
 			"integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/@types/babel__core": {
 			"version": "7.20.0",
@@ -2591,7 +2586,6 @@
 			"resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.4.tgz",
 			"integrity": "sha512-9K4zoImiZc3HlIp6AVUDE4CWYx22a+lhSZMYNpbjW04+YF0KWj4pJXnEMjdnFTiQibFFmElcsasJXDbdI/EPhA==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@types/eslint": "*",
 				"@types/estree": "*"
@@ -2601,8 +2595,7 @@
 			"version": "0.0.51",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
 			"integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/@types/graceful-fs": {
 			"version": "4.1.6",
@@ -2669,6 +2662,7 @@
 			"integrity": "sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"undici-types": "~6.21.0"
 			}
@@ -2837,6 +2831,7 @@
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.49.0.tgz",
 			"integrity": "sha512-veDlZN9mUhGqU31Qiv2qEp+XrJj5fgZpJ8PW30sHU+j/8/e5ruAhLaVDAeznS7A7i4ucb/s8IozpDtt9NqCkZg==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "5.49.0",
 				"@typescript-eslint/types": "5.49.0",
@@ -3021,7 +3016,6 @@
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",
 			"integrity": "sha512-ukBh14qFLjxTQNTXocdyksN5QdM28S1CxHt2rdskFyL+xFV7VremuBLVbmCePj+URalXBENx/9Lm7lnhihtCSw==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@webassemblyjs/helper-numbers": "1.11.1",
 				"@webassemblyjs/helper-wasm-bytecode": "1.11.1"
@@ -3031,29 +3025,25 @@
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.1.tgz",
 			"integrity": "sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/@webassemblyjs/helper-api-error": {
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.1.tgz",
 			"integrity": "sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/@webassemblyjs/helper-buffer": {
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.1.tgz",
 			"integrity": "sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/@webassemblyjs/helper-numbers": {
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.1.tgz",
 			"integrity": "sha512-vDkbxiB8zfnPdNK9Rajcey5C0w+QJugEglN0of+kmO8l7lDb77AnlKYQF7aarZuCrv+l0UvqL+68gSDr3k9LPQ==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@webassemblyjs/floating-point-hex-parser": "1.11.1",
 				"@webassemblyjs/helper-api-error": "1.11.1",
@@ -3064,15 +3054,13 @@
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.1.tgz",
 			"integrity": "sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/@webassemblyjs/helper-wasm-section": {
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.1.tgz",
 			"integrity": "sha512-10P9No29rYX1j7F3EVPX3JvGPQPae+AomuSTPiF9eBQeChHI6iqjMIwR9JmOJXwpnn/oVGDk7I5IlskuMwU/pg==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@webassemblyjs/ast": "1.11.1",
 				"@webassemblyjs/helper-buffer": "1.11.1",
@@ -3085,7 +3073,6 @@
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.1.tgz",
 			"integrity": "sha512-hJ87QIPtAMKbFq6CGTkZYJivEwZDbQUgYd3qKSadTNOhVY7p+gfP6Sr0lLRVTaG1JjFj+r3YchoqRYxNH3M0GQ==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@xtuc/ieee754": "^1.2.0"
 			}
@@ -3095,7 +3082,6 @@
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.1.tgz",
 			"integrity": "sha512-BJ2P0hNZ0u+Th1YZXJpzW6miwqQUGcIHT1G/sf72gLVD9DZ5AdYTqPNbHZh6K1M5VmKvFXwGSWZADz+qBWxeRw==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@xtuc/long": "4.2.2"
 			}
@@ -3104,15 +3090,13 @@
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.1.tgz",
 			"integrity": "sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/@webassemblyjs/wasm-edit": {
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.1.tgz",
 			"integrity": "sha512-g+RsupUC1aTHfR8CDgnsVRVZFJqdkFHpsHMfJuWQzWU3tvnLC07UqHICfP+4XyL2tnr1amvl1Sdp06TnYCmVkA==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@webassemblyjs/ast": "1.11.1",
 				"@webassemblyjs/helper-buffer": "1.11.1",
@@ -3129,7 +3113,6 @@
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.1.tgz",
 			"integrity": "sha512-F7QqKXwwNlMmsulj6+O7r4mmtAlCWfO/0HdgOxSklZfQcDu0TpLiD1mRt/zF25Bk59FIjEuGAIyn5ei4yMfLhA==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@webassemblyjs/ast": "1.11.1",
 				"@webassemblyjs/helper-wasm-bytecode": "1.11.1",
@@ -3143,7 +3126,6 @@
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.1.tgz",
 			"integrity": "sha512-VqnkNqnZlU5EB64pp1l7hdm3hmQw7Vgqa0KF/KCNO9sIpI6Fk6brDEiX+iCOYrvMuBWDws0NkTOxYEb85XQHHw==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@webassemblyjs/ast": "1.11.1",
 				"@webassemblyjs/helper-buffer": "1.11.1",
@@ -3156,7 +3138,6 @@
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.1.tgz",
 			"integrity": "sha512-rrBujw+dJu32gYB7/Lup6UhdkPx9S9SnobZzRVL7VcBH9Bt9bCBLEuX/YXOOtBsOZ4NQrRykKhffRWHvigQvOA==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@webassemblyjs/ast": "1.11.1",
 				"@webassemblyjs/helper-api-error": "1.11.1",
@@ -3171,7 +3152,6 @@
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.11.1.tgz",
 			"integrity": "sha512-IQboUWM4eKzWW+N/jij2sRatKMh99QEelo3Eb2q0qXkvPRISAj8Qxtmw5itwqK+TTkBuUIE45AxYPToqPtL5gg==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@webassemblyjs/ast": "1.11.1",
 				"@xtuc/long": "4.2.2"
@@ -3181,20 +3161,19 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
 			"integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/@xtuc/long": {
 			"version": "4.2.2",
 			"resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
 			"integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/acorn": {
 			"version": "8.8.1",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
 			"integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
+			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -3207,7 +3186,6 @@
 			"resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
 			"integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
 			"dev": true,
-			"peer": true,
 			"peerDependencies": {
 				"acorn": "^8"
 			}
@@ -3224,6 +3202,7 @@
 			"version": "6.12.6",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
 			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -3305,8 +3284,7 @@
 			"version": "4.1.3",
 			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
 			"integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/argparse": {
 			"version": "2.0.1",
@@ -3753,6 +3731,7 @@
 					"url": "https://tidelift.com/funding/github/npm/browserslist"
 				}
 			],
+			"peer": true,
 			"dependencies": {
 				"caniuse-lite": "^1.0.30001400",
 				"electron-to-chromium": "^1.4.251",
@@ -3903,7 +3882,6 @@
 			"resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
 			"integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">=6.0"
 			}
@@ -4014,8 +3992,7 @@
 			"version": "2.20.3",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
 			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/concat-map": {
 			"version": "0.0.1",
@@ -4204,8 +4181,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
 			"integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.6",
@@ -4367,7 +4343,6 @@
 			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
 			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">=0.3.1"
 			}
@@ -4607,8 +4582,7 @@
 			"version": "0.9.3",
 			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
 			"integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/es-object-atoms": {
 			"version": "1.1.1",
@@ -4683,6 +4657,7 @@
 			"version": "8.32.0",
 			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.32.0.tgz",
 			"integrity": "sha512-nETVXpnthqKPFyuY2FNjz/bEd6nbosRgKbkgS/y1C7LJop96gYHWpiguLecMHQ2XCPxn77DS0P+68WzG6vkZSQ==",
+			"peer": true,
 			"dependencies": {
 				"@eslint/eslintrc": "^1.4.1",
 				"@humanwhocodes/config-array": "^0.11.8",
@@ -4740,6 +4715,7 @@
 			"integrity": "sha512-/IGJ6+Dka158JnP5n5YFMOszjDWrXggGz1LaK/guZq9vZTmniaKlHcsscvkAhn9y4U+BU3JuUdYvtAMcv30y4A==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"eslint-config-prettier": "bin/cli.js"
 			},
@@ -5276,7 +5252,6 @@
 			"resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
 			"integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">=0.8.x"
 			}
@@ -5947,8 +5922,7 @@
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
 			"integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/globals": {
 			"version": "11.12.0",
@@ -6110,7 +6084,8 @@
 		"node_modules/highcharts": {
 			"version": "9.0.1",
 			"resolved": "https://registry.npmjs.org/highcharts/-/highcharts-9.0.1.tgz",
-			"integrity": "sha512-0UmcCz2RmFuqfT/Igu3h5sGnkeSqqZwfuYrTzJ/htptmJAo5SSxH62NFcTjVRk+3WstoBJmoXR0v5FVGQUzK5A=="
+			"integrity": "sha512-0UmcCz2RmFuqfT/Igu3h5sGnkeSqqZwfuYrTzJ/htptmJAo5SSxH62NFcTjVRk+3WstoBJmoXR0v5FVGQUzK5A==",
+			"peer": true
 		},
 		"node_modules/highcharts-react-official": {
 			"version": "3.1.0",
@@ -8523,6 +8498,7 @@
 			"resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
 			"integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">= 10.16.0"
 			}
@@ -8720,7 +8696,6 @@
 			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
 			"integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">=6.11.5"
 			}
@@ -9045,8 +9020,7 @@
 			"version": "1.3.6",
 			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
 			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/makeerror": {
 			"version": "1.0.12",
@@ -9208,8 +9182,7 @@
 			"version": "2.6.2",
 			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
 			"integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/next": {
 			"version": "12.3.7",
@@ -9733,6 +9706,7 @@
 			"integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"prettier": "bin/prettier.cjs"
 			},
@@ -9834,6 +9808,7 @@
 			"version": "15.7.2",
 			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
 			"integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+			"peer": true,
 			"dependencies": {
 				"loose-envify": "^1.4.0",
 				"object-assign": "^4.1.1",
@@ -9900,7 +9875,6 @@
 			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
 			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"safe-buffer": "^5.1.0"
 			}
@@ -9909,6 +9883,7 @@
 			"version": "17.0.2",
 			"resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
 			"integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+			"peer": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1"
@@ -9955,6 +9930,7 @@
 			"version": "17.0.2",
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
 			"integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
+			"peer": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1",
@@ -10680,7 +10656,6 @@
 			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.1.tgz",
 			"integrity": "sha512-owoXEFjWRllis8/M1Q+Cw5k8ZH40e3zhp/ovX+Xr/vi1qj6QesbyXXViFbpNvWvPNAD62SutwEXavefrLJWj7w==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"randombytes": "^2.1.0"
 			}
@@ -11088,7 +11063,6 @@
 			"resolved": "https://registry.npmjs.org/terser/-/terser-5.16.1.tgz",
 			"integrity": "sha512-xvQfyfA1ayT0qdK47zskQgRZeWLoOQ8JQ6mIgRGVNwZKdQMU+5FkCBjmv4QjcrTzyZquRw2FVtlJSRUmMKQslw==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@jridgewell/source-map": "^0.3.2",
 				"acorn": "^8.5.0",
@@ -11107,7 +11081,6 @@
 			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.6.tgz",
 			"integrity": "sha512-kfLFk+PoLUQIbLmB1+PZDMRSZS99Mp+/MHqDNmMA6tOItzRt+Npe3E+fsMs5mfcM0wCtrrdU387UnV+vnSffXQ==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@jridgewell/trace-mapping": "^0.3.14",
 				"jest-worker": "^27.4.5",
@@ -11142,7 +11115,6 @@
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
 			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -11152,7 +11124,6 @@
 			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
 			"integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@types/node": "*",
 				"merge-stream": "^2.0.0",
@@ -11167,7 +11138,6 @@
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
 			"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"has-flag": "^4.0.0"
 			},
@@ -11183,7 +11153,6 @@
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -11193,7 +11162,6 @@
 			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
 			"integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"buffer-from": "^1.0.0",
 				"source-map": "^0.6.0"
@@ -11323,7 +11291,6 @@
 			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
 			"integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">=0.4.0"
 			}
@@ -11428,6 +11395,7 @@
 			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -11561,8 +11529,7 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
 			"integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/v8-to-istanbul": {
 			"version": "9.0.1",
@@ -11605,7 +11572,6 @@
 			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
 			"integrity": "sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"glob-to-regexp": "^0.4.1",
 				"graceful-fs": "^4.1.2"
@@ -11667,7 +11633,6 @@
 			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
 			"integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">=10.13.0"
 			}
@@ -11929,7 +11894,6 @@
 			"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
 			"integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">=6"
 			}
@@ -12010,6 +11974,7 @@
 			"version": "7.20.12",
 			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.20.12.tgz",
 			"integrity": "sha512-XsMfHovsUYHFMdrIHkZphTN/2Hzzi78R08NuHfDBehym2VsPDL6Zn/JAD/JQdnRvbSsbQc4mVaU1m6JgtTEElg==",
+			"peer": true,
 			"requires": {
 				"@ampproject/remapping": "^2.1.0",
 				"@babel/code-frame": "^7.18.6",
@@ -12499,7 +12464,6 @@
 			"resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
 			"integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"@jridgewell/trace-mapping": "0.3.9"
 			},
@@ -12509,7 +12473,6 @@
 					"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
 					"integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
 					"dev": true,
-					"peer": true,
 					"requires": {
 						"@jridgewell/resolve-uri": "^3.0.3",
 						"@jridgewell/sourcemap-codec": "^1.4.10"
@@ -13400,7 +13363,6 @@
 			"resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
 			"integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"@jridgewell/gen-mapping": "^0.3.0",
 				"@jridgewell/trace-mapping": "^0.3.9"
@@ -13630,7 +13592,8 @@
 		"@popperjs/core": {
 			"version": "2.11.8",
 			"resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
-			"integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A=="
+			"integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+			"peer": true
 		},
 		"@reach/component-component": {
 			"version": "0.17.0",
@@ -13696,29 +13659,25 @@
 			"version": "1.0.9",
 			"resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
 			"integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"@tsconfig/node12": {
 			"version": "1.0.11",
 			"resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
 			"integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"@tsconfig/node14": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
 			"integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"@tsconfig/node16": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
 			"integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"@types/babel__core": {
 			"version": "7.20.0",
@@ -13777,7 +13736,6 @@
 			"resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.4.tgz",
 			"integrity": "sha512-9K4zoImiZc3HlIp6AVUDE4CWYx22a+lhSZMYNpbjW04+YF0KWj4pJXnEMjdnFTiQibFFmElcsasJXDbdI/EPhA==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"@types/eslint": "*",
 				"@types/estree": "*"
@@ -13787,8 +13745,7 @@
 			"version": "0.0.51",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
 			"integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"@types/graceful-fs": {
 			"version": "4.1.6",
@@ -13854,6 +13811,7 @@
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.14.1.tgz",
 			"integrity": "sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw==",
 			"dev": true,
+			"peer": true,
 			"requires": {
 				"undici-types": "~6.21.0"
 			}
@@ -13996,6 +13954,7 @@
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.49.0.tgz",
 			"integrity": "sha512-veDlZN9mUhGqU31Qiv2qEp+XrJj5fgZpJ8PW30sHU+j/8/e5ruAhLaVDAeznS7A7i4ucb/s8IozpDtt9NqCkZg==",
 			"dev": true,
+			"peer": true,
 			"requires": {
 				"@typescript-eslint/scope-manager": "5.49.0",
 				"@typescript-eslint/types": "5.49.0",
@@ -14099,7 +14058,6 @@
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",
 			"integrity": "sha512-ukBh14qFLjxTQNTXocdyksN5QdM28S1CxHt2rdskFyL+xFV7VremuBLVbmCePj+URalXBENx/9Lm7lnhihtCSw==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"@webassemblyjs/helper-numbers": "1.11.1",
 				"@webassemblyjs/helper-wasm-bytecode": "1.11.1"
@@ -14109,29 +14067,25 @@
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.1.tgz",
 			"integrity": "sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"@webassemblyjs/helper-api-error": {
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.1.tgz",
 			"integrity": "sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"@webassemblyjs/helper-buffer": {
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.1.tgz",
 			"integrity": "sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"@webassemblyjs/helper-numbers": {
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.1.tgz",
 			"integrity": "sha512-vDkbxiB8zfnPdNK9Rajcey5C0w+QJugEglN0of+kmO8l7lDb77AnlKYQF7aarZuCrv+l0UvqL+68gSDr3k9LPQ==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"@webassemblyjs/floating-point-hex-parser": "1.11.1",
 				"@webassemblyjs/helper-api-error": "1.11.1",
@@ -14142,15 +14096,13 @@
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.1.tgz",
 			"integrity": "sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"@webassemblyjs/helper-wasm-section": {
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.1.tgz",
 			"integrity": "sha512-10P9No29rYX1j7F3EVPX3JvGPQPae+AomuSTPiF9eBQeChHI6iqjMIwR9JmOJXwpnn/oVGDk7I5IlskuMwU/pg==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.11.1",
 				"@webassemblyjs/helper-buffer": "1.11.1",
@@ -14163,7 +14115,6 @@
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.1.tgz",
 			"integrity": "sha512-hJ87QIPtAMKbFq6CGTkZYJivEwZDbQUgYd3qKSadTNOhVY7p+gfP6Sr0lLRVTaG1JjFj+r3YchoqRYxNH3M0GQ==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"@xtuc/ieee754": "^1.2.0"
 			}
@@ -14173,7 +14124,6 @@
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.1.tgz",
 			"integrity": "sha512-BJ2P0hNZ0u+Th1YZXJpzW6miwqQUGcIHT1G/sf72gLVD9DZ5AdYTqPNbHZh6K1M5VmKvFXwGSWZADz+qBWxeRw==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"@xtuc/long": "4.2.2"
 			}
@@ -14182,15 +14132,13 @@
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.1.tgz",
 			"integrity": "sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"@webassemblyjs/wasm-edit": {
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.1.tgz",
 			"integrity": "sha512-g+RsupUC1aTHfR8CDgnsVRVZFJqdkFHpsHMfJuWQzWU3tvnLC07UqHICfP+4XyL2tnr1amvl1Sdp06TnYCmVkA==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.11.1",
 				"@webassemblyjs/helper-buffer": "1.11.1",
@@ -14207,7 +14155,6 @@
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.1.tgz",
 			"integrity": "sha512-F7QqKXwwNlMmsulj6+O7r4mmtAlCWfO/0HdgOxSklZfQcDu0TpLiD1mRt/zF25Bk59FIjEuGAIyn5ei4yMfLhA==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.11.1",
 				"@webassemblyjs/helper-wasm-bytecode": "1.11.1",
@@ -14221,7 +14168,6 @@
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.1.tgz",
 			"integrity": "sha512-VqnkNqnZlU5EB64pp1l7hdm3hmQw7Vgqa0KF/KCNO9sIpI6Fk6brDEiX+iCOYrvMuBWDws0NkTOxYEb85XQHHw==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.11.1",
 				"@webassemblyjs/helper-buffer": "1.11.1",
@@ -14234,7 +14180,6 @@
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.1.tgz",
 			"integrity": "sha512-rrBujw+dJu32gYB7/Lup6UhdkPx9S9SnobZzRVL7VcBH9Bt9bCBLEuX/YXOOtBsOZ4NQrRykKhffRWHvigQvOA==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.11.1",
 				"@webassemblyjs/helper-api-error": "1.11.1",
@@ -14249,7 +14194,6 @@
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.11.1.tgz",
 			"integrity": "sha512-IQboUWM4eKzWW+N/jij2sRatKMh99QEelo3Eb2q0qXkvPRISAj8Qxtmw5itwqK+TTkBuUIE45AxYPToqPtL5gg==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.11.1",
 				"@xtuc/long": "4.2.2"
@@ -14259,27 +14203,25 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
 			"integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"@xtuc/long": {
 			"version": "4.2.2",
 			"resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
 			"integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"acorn": {
 			"version": "8.8.1",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
-			"integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA=="
+			"integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
+			"peer": true
 		},
 		"acorn-import-assertions": {
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
 			"integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
 			"dev": true,
-			"peer": true,
 			"requires": {}
 		},
 		"acorn-jsx": {
@@ -14292,6 +14234,7 @@
 			"version": "6.12.6",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
 			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+			"peer": true,
 			"requires": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -14327,8 +14270,7 @@
 			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
 		},
 		"ansi-styles": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"version": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 			"requires": {
 				"color-convert": "^1.9.0"
@@ -14348,8 +14290,7 @@
 			"version": "4.1.3",
 			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
 			"integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"argparse": {
 			"version": "2.0.1",
@@ -14695,6 +14636,7 @@
 			"version": "4.21.4",
 			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
 			"integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
+			"peer": true,
 			"requires": {
 				"caniuse-lite": "^1.0.30001400",
 				"electron-to-chromium": "^1.4.251",
@@ -14798,8 +14740,7 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
 			"integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"cjs-module-lexer": {
 			"version": "1.2.2",
@@ -14893,8 +14834,7 @@
 			"version": "2.20.3",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
 			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"concat-map": {
 			"version": "0.0.1",
@@ -15035,8 +14975,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
 			"integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"cross-spawn": {
 			"version": "7.0.6",
@@ -15161,8 +15100,7 @@
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
 			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"diff-sequences": {
 			"version": "29.3.1",
@@ -15357,8 +15295,7 @@
 			"version": "0.9.3",
 			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
 			"integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"es-object-atoms": {
 			"version": "1.1.1",
@@ -15413,6 +15350,7 @@
 			"version": "8.32.0",
 			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.32.0.tgz",
 			"integrity": "sha512-nETVXpnthqKPFyuY2FNjz/bEd6nbosRgKbkgS/y1C7LJop96gYHWpiguLecMHQ2XCPxn77DS0P+68WzG6vkZSQ==",
+			"peer": true,
 			"requires": {
 				"@eslint/eslintrc": "^1.4.1",
 				"@humanwhocodes/config-array": "^0.11.8",
@@ -15580,6 +15518,7 @@
 			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.10.2.tgz",
 			"integrity": "sha512-/IGJ6+Dka158JnP5n5YFMOszjDWrXggGz1LaK/guZq9vZTmniaKlHcsscvkAhn9y4U+BU3JuUdYvtAMcv30y4A==",
 			"dev": true,
+			"peer": true,
 			"requires": {}
 		},
 		"eslint-import-resolver-babel-module": {
@@ -15834,8 +15773,7 @@
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
 			"integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"exit": {
 			"version": "0.1.2",
@@ -16328,8 +16266,7 @@
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
 			"integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"globals": {
 			"version": "11.12.0",
@@ -16433,7 +16370,8 @@
 		"highcharts": {
 			"version": "9.0.1",
 			"resolved": "https://registry.npmjs.org/highcharts/-/highcharts-9.0.1.tgz",
-			"integrity": "sha512-0UmcCz2RmFuqfT/Igu3h5sGnkeSqqZwfuYrTzJ/htptmJAo5SSxH62NFcTjVRk+3WstoBJmoXR0v5FVGQUzK5A=="
+			"integrity": "sha512-0UmcCz2RmFuqfT/Igu3h5sGnkeSqqZwfuYrTzJ/htptmJAo5SSxH62NFcTjVRk+3WstoBJmoXR0v5FVGQUzK5A==",
+			"peer": true
 		},
 		"highcharts-react-official": {
 			"version": "3.1.0",
@@ -18199,7 +18137,8 @@
 		"jsep": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
-			"integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw=="
+			"integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
+			"peer": true
 		},
 		"jsesc": {
 			"version": "2.5.2",
@@ -18363,8 +18302,7 @@
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
 			"integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"loaders.css": {
 			"version": "0.1.2",
@@ -18661,8 +18599,7 @@
 			"version": "1.3.6",
 			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
 			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"makeerror": {
 			"version": "1.0.12",
@@ -18778,8 +18715,7 @@
 			"version": "2.6.2",
 			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
 			"integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"next": {
 			"version": "12.3.7",
@@ -19133,7 +19069,8 @@
 			"version": "3.6.2",
 			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
 			"integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"prettier-linter-helpers": {
 			"version": "1.0.0",
@@ -19203,6 +19140,7 @@
 			"version": "15.7.2",
 			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
 			"integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+			"peer": true,
 			"requires": {
 				"loose-envify": "^1.4.0",
 				"object-assign": "^4.1.1",
@@ -19245,7 +19183,6 @@
 			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
 			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"safe-buffer": "^5.1.0"
 			}
@@ -19254,6 +19191,7 @@
 			"version": "17.0.2",
 			"resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
 			"integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+			"peer": true,
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1"
@@ -19286,6 +19224,7 @@
 			"version": "17.0.2",
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
 			"integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
+			"peer": true,
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1",
@@ -19843,7 +19782,6 @@
 			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.1.tgz",
 			"integrity": "sha512-owoXEFjWRllis8/M1Q+Cw5k8ZH40e3zhp/ovX+Xr/vi1qj6QesbyXXViFbpNvWvPNAD62SutwEXavefrLJWj7w==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"randombytes": "^2.1.0"
 			}
@@ -20140,7 +20078,6 @@
 			"resolved": "https://registry.npmjs.org/terser/-/terser-5.16.1.tgz",
 			"integrity": "sha512-xvQfyfA1ayT0qdK47zskQgRZeWLoOQ8JQ6mIgRGVNwZKdQMU+5FkCBjmv4QjcrTzyZquRw2FVtlJSRUmMKQslw==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"@jridgewell/source-map": "^0.3.2",
 				"acorn": "^8.5.0",
@@ -20152,15 +20089,13 @@
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true,
-					"peer": true
+					"dev": true
 				},
 				"source-map-support": {
 					"version": "0.5.21",
 					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
 					"integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
 					"dev": true,
-					"peer": true,
 					"requires": {
 						"buffer-from": "^1.0.0",
 						"source-map": "^0.6.0"
@@ -20173,7 +20108,6 @@
 			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.6.tgz",
 			"integrity": "sha512-kfLFk+PoLUQIbLmB1+PZDMRSZS99Mp+/MHqDNmMA6tOItzRt+Npe3E+fsMs5mfcM0wCtrrdU387UnV+vnSffXQ==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"@jridgewell/trace-mapping": "^0.3.14",
 				"jest-worker": "^27.4.5",
@@ -20186,15 +20120,13 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
 					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true,
-					"peer": true
+					"dev": true
 				},
 				"jest-worker": {
 					"version": "27.5.1",
 					"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
 					"integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
 					"dev": true,
-					"peer": true,
 					"requires": {
 						"@types/node": "*",
 						"merge-stream": "^2.0.0",
@@ -20206,7 +20138,6 @@
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
 					"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
 					"dev": true,
-					"peer": true,
 					"requires": {
 						"has-flag": "^4.0.0"
 					}
@@ -20301,8 +20232,7 @@
 					"version": "8.2.0",
 					"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
 					"integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
-					"dev": true,
-					"peer": true
+					"dev": true
 				}
 			}
 		},
@@ -20377,7 +20307,8 @@
 			"version": "5.9.3",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
 			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"typescript-transform-paths": {
 			"version": "3.4.6",
@@ -20459,8 +20390,7 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
 			"integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"v8-to-istanbul": {
 			"version": "9.0.1",
@@ -20500,7 +20430,6 @@
 			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
 			"integrity": "sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"glob-to-regexp": "^0.4.1",
 				"graceful-fs": "^4.1.2"
@@ -20543,8 +20472,7 @@
 			"version": "3.2.3",
 			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
 			"integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"whatwg-fetch": {
 			"version": "2.0.4",
@@ -20734,8 +20662,7 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
 			"integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"yocto-queue": {
 			"version": "0.1.0",


### PR DESCRIPTION
# Description
Enhancement to append more sequencing files to an open Submission according certain conditions allowing users to add missing sequencing files to existing open Submission, a description of this behaviour is displayed to the user in highlighted text.

## Details
- Append sequencing files only is enable when the previous Submission is in `VALID` status, which means the `.csv`  records were validated and found no errors, additionally, the previous Submission has to contain pending to upload sequencing files. (using score client)

- Included a conditional banner with a descriptive text when the tar append sequencing files is permitted.
<img width="716" height="238" alt="image" src="https://github.com/user-attachments/assets/1307d950-2266-43a9-9892-7ce249e75b85" />

- Confirmation modal text updates:
<img width="874" height="233" alt="image" src="https://github.com/user-attachments/assets/d962ca91-2c33-4067-8754-00b45ac2765d" />
