### PR TITLE
Confirm submission button

### DIFF
--- a/components/pages/submission/Environmental/Details/index.tsx
+++ b/components/pages/submission/Environmental/Details/index.tsx
@@ -111,10 +111,15 @@ const SubmissionDetails = ({ ID }: SubmissionDetailsProps): ReactElement => {
 	 */
 	const commit = useCallback(
 		async (signal?: AbortSignal) => {
-			await commitSubmission(ID, { signal });
+			const commitSubmissionResponse = await commitSubmission(ID, { signal });
+			const isCommitErrorResponse =
+				'error' in commitSubmissionResponse && typeof commitSubmissionResponse.error === 'string';
 			if (submissionSummaryStreamRef.current?.readyState === EventSource.CLOSED) {
 				// Re-open the event stream if it's closed to listen for new updates after commit
 				getSubmissionOverview();
+			} else if (isCommitErrorResponse && commitSubmissionResponse.error === 'Conflict') {
+				// Displays the banner for missing files if the commit fails due to missing files
+				setPendingUploadManifests(getPendingUploadFileManifests(submissionOverview?.submissionFiles));
 			}
 		},
 		[commitSubmission, ID],

--- a/components/pages/submission/Environmental/Details/index.tsx
+++ b/components/pages/submission/Environmental/Details/index.tsx
@@ -34,8 +34,8 @@ import useEnvironmentalData, {
 	type SubmissionSummary,
 } from '#global/hooks/useEnvironmentalData';
 import type { SubmissionManifest } from '#global/utils/fileManifest';
+import Button from '#components/Button';
 
-import Button from '../../../../Button';
 import FileUploadInstructionsModal from '../NewSubmissions/FileUploadInstructionsModal';
 
 import columns from './columns';
@@ -112,7 +112,7 @@ const SubmissionDetails = ({ ID }: SubmissionDetailsProps): ReactElement => {
 	const commit = useCallback(
 		async (signal?: AbortSignal) => {
 			await commitSubmission(ID, { signal });
-			// 	Re-open the event stream if it's closed to listen for new updates after commit
+			// Re-open the event stream if it's closed to listen for new updates after commit
 			getSubmissionOverview();
 		},
 		[commitSubmission, ID],

--- a/components/pages/submission/Environmental/Details/index.tsx
+++ b/components/pages/submission/Environmental/Details/index.tsx
@@ -112,8 +112,10 @@ const SubmissionDetails = ({ ID }: SubmissionDetailsProps): ReactElement => {
 	const commit = useCallback(
 		async (signal?: AbortSignal) => {
 			await commitSubmission(ID, { signal });
-			// Re-open the event stream if it's closed to listen for new updates after commit
-			getSubmissionOverview();
+			if (submissionSummaryStreamRef.current?.readyState === EventSource.CLOSED) {
+				// Re-open the event stream if it's closed to listen for new updates after commit
+				getSubmissionOverview();
+			}
 		},
 		[commitSubmission, ID],
 	);

--- a/components/pages/submission/Environmental/Details/index.tsx
+++ b/components/pages/submission/Environmental/Details/index.tsx
@@ -105,6 +105,34 @@ const SubmissionDetails = ({ ID }: SubmissionDetailsProps): ReactElement => {
 	}, [submissionRecords, submissionRecordsDispatch]);
 
 	/**
+	 * Fetch the Submission general information such as status, organization, total records, and files.
+	 */
+	const getSubmissionOverview = useCallback(() => {
+		submissionSummaryStreamRef.current = fetchSubmissionSummaryById(ID, (messageData: SubmissionSummary) => {
+			const { organization, createdAt, id, status, files, data } = messageData;
+			const totalRecordsCount = data.total;
+
+			// Data to display in Overview table
+			setSubmissionOverview({
+				createdAt,
+				submissionFiles: files || [],
+				submissionId: id.toString(),
+				totalRecords: totalRecordsCount,
+				organization,
+				status,
+			});
+
+			const filesNotUploaded = getPendingUploadFileManifests(files);
+
+			setPendingUploadManifests(filesNotUploaded);
+
+			// Total amount of records uploading
+			const totalPages = Math.ceil(totalRecordsCount / pageSize);
+			setLastPage(totalPages);
+		});
+	}, [fetchSubmissionSummaryById, ID]);
+
+	/**
 	 * Commit submission to Submission Service.
 	 * If the Submission is successfully commited (i.e. 'PROCESSING' status)
 	 * and the stream connection is closed, it will re-open the stream to listen for further updates after commit.
@@ -125,7 +153,7 @@ const SubmissionDetails = ({ ID }: SubmissionDetailsProps): ReactElement => {
 				setPendingUploadManifests(getPendingUploadFileManifests(submissionOverview?.submissionFiles));
 			}
 		},
-		[commitSubmission, ID],
+		[commitSubmission, submissionOverview, getSubmissionOverview, ID],
 	);
 
 	/**
@@ -240,34 +268,6 @@ const SubmissionDetails = ({ ID }: SubmissionDetailsProps): ReactElement => {
 		},
 		[submissionRecords, getAnalysisIds, submissionRecordsDispatch, setDataIsPending, completeAllProcessingRecords],
 	);
-
-	/**
-	 * Fetch the Submission general information such as status, organization, total records, and files.
-	 */
-	const getSubmissionOverview = useCallback(() => {
-		submissionSummaryStreamRef.current = fetchSubmissionSummaryById(ID, (messageData: SubmissionSummary) => {
-			const { organization, createdAt, id, status, files, data } = messageData;
-			const totalRecordsCount = data.total;
-
-			// Data to display in Overview table
-			setSubmissionOverview({
-				createdAt,
-				submissionFiles: files || [],
-				submissionId: id.toString(),
-				totalRecords: totalRecordsCount,
-				organization,
-				status,
-			});
-
-			const filesNotUploaded = getPendingUploadFileManifests(files);
-
-			setPendingUploadManifests(filesNotUploaded);
-
-			// Total amount of records uploading
-			const totalPages = Math.ceil(totalRecordsCount / pageSize);
-			setLastPage(totalPages);
-		});
-	}, [fetchSubmissionSummaryById, ID]);
 
 	// gets the initial status for all the uploads
 	useEffect(() => {

--- a/components/pages/submission/Environmental/Details/index.tsx
+++ b/components/pages/submission/Environmental/Details/index.tsx
@@ -35,6 +35,7 @@ import useEnvironmentalData, {
 } from '#global/hooks/useEnvironmentalData';
 import type { SubmissionManifest } from '#global/utils/fileManifest';
 
+import Button from '../../../../Button';
 import FileUploadInstructionsModal from '../NewSubmissions/FileUploadInstructionsModal';
 
 import columns from './columns';
@@ -110,14 +111,9 @@ const SubmissionDetails = ({ ID }: SubmissionDetailsProps): ReactElement => {
 	 */
 	const commit = useCallback(
 		async (signal?: AbortSignal) => {
-			const commitSubmissionResponse = await commitSubmission(ID, { signal });
-			if (
-				commitSubmissionResponse.status === UploadStatus.PROCESSING &&
-				submissionSummaryStreamRef.current?.readyState === EventSource.CLOSED
-			) {
-				// Re-open the event stream if it's closed to listen for new updates after commit
-				getSubmissionOverview();
-			}
+			await commitSubmission(ID, { signal });
+			// 	Re-open the event stream if it's closed to listen for new updates after commit
+			getSubmissionOverview();
 		},
 		[commitSubmission, ID],
 	);
@@ -290,8 +286,7 @@ const SubmissionDetails = ({ ID }: SubmissionDetailsProps): ReactElement => {
 		}
 
 		if (submissionOverview.status === SubmissionStatus.VALID) {
-			// Trigger submission commit when the current status is 'VALID'
-			commit(controller.signal);
+			// If the submission is valid, we can stop tracking pending data
 			return;
 		}
 
@@ -351,15 +346,42 @@ const SubmissionDetails = ({ ID }: SubmissionDetailsProps): ReactElement => {
 			>
 				{submissionOverview && submissionOverview.totalRecords > 0 && (
 					<>
-						<p
+						<div
 							css={css`
-								display: block;
-								font-size: 13px;
+								display: flex;
+								align-items: center;
+								justify-content: space-between;
 								margin: 10px 0;
+								width: 100%;
+								gap: 10px;
 							`}
 						>
-							{firstRecord} - {lastRecord} of {submissionOverview.totalRecords} Viral Genomes
-						</p>
+							<p
+								css={css`
+									display: block;
+									font-size: 13px;
+									margin: 0;
+								`}
+							>
+								{firstRecord} - {lastRecord} of {submissionOverview.totalRecords} Viral Genomes
+							</p>
+							{submissionOverview.status === SubmissionStatus.VALID &&
+								pendingUploadManifests.length === 0 && (
+									<Button
+										css={css`
+											background-color: ${theme.colors.success_dark};
+											padding-top: 0px;
+											padding-bottom: 0px;
+											padding-left: 10px;
+											padding-right: 10px;
+											margin: 0;
+										`}
+										onClick={() => commit()}
+									>
+										Confirm Submission
+									</Button>
+								)}
+						</div>
 						<GenericTable
 							columns={columns}
 							data={Object.values(submissionRecords).flat()}
@@ -424,10 +446,10 @@ const SubmissionDetails = ({ ID }: SubmissionDetailsProps): ReactElement => {
 						submissionManifest={pendingUploadManifests}
 						submissionId={ID}
 						onClose={() => {
+							// Close the modal
 							setOpenGuideModal(false);
-							// Closing the modal will trigger submission commit to verify if
-							// files have been uploaded.
-							commit();
+							// Clean the pending upload banner since the user has seen the instructions
+							setPendingUploadManifests([]);
 						}}
 					/>
 				)}

--- a/components/pages/submission/Environmental/Details/index.tsx
+++ b/components/pages/submission/Environmental/Details/index.tsx
@@ -114,10 +114,13 @@ const SubmissionDetails = ({ ID }: SubmissionDetailsProps): ReactElement => {
 			const commitSubmissionResponse = await commitSubmission(ID, { signal });
 			const isCommitErrorResponse =
 				'error' in commitSubmissionResponse && typeof commitSubmissionResponse.error === 'string';
+
 			if (submissionSummaryStreamRef.current?.readyState === EventSource.CLOSED) {
 				// Re-open the event stream if it's closed to listen for new updates after commit
 				getSubmissionOverview();
-			} else if (isCommitErrorResponse && commitSubmissionResponse.error === 'Conflict') {
+			}
+
+			if (isCommitErrorResponse && commitSubmissionResponse.error === 'Conflict') {
 				// Displays the banner for missing files if the commit fails due to missing files
 				setPendingUploadManifests(getPendingUploadFileManifests(submissionOverview?.submissionFiles));
 			}

--- a/components/pages/submission/Environmental/NewSubmissions/index.tsx
+++ b/components/pages/submission/Environmental/NewSubmissions/index.tsx
@@ -30,14 +30,12 @@ import StyledLink from '#components/Link';
 import { LoaderWrapper } from '#components/Loader';
 import useAuthContext from '#global/hooks/useAuthContext';
 import useEnvironmentalData, { type SubmissionSummary } from '#global/hooks/useEnvironmentalData';
-import type { SubmissionManifest } from '#global/utils/fileManifest';
 import getInternalLink from '#global/utils/getInternalLink';
 import ConfirmSubmissionModal from '#components/pages/submission/ConfirmSubmissionModal';
 
 import DropZone from './DropZone';
 import ErrorMessage from './ErrorMessage';
 import FileRow from './FileRow';
-import FileUploadInstructionsModal from './FileUploadInstructionsModal';
 import { CreateSubmissionStatus, ValidationAction, type BatchError, type SubmissionFile } from './types';
 import {
 	buildFormData,
@@ -70,13 +68,10 @@ const NewSubmissions = (): ReactElement => {
 		useAuthContext();
 	const theme = useTheme();
 	const [confirmSubmissionModalOpen, setConfirmSubmissionModalOpen] = useState(false);
-	const [filesSubmissionInstructions, setFilesSubmissionInstructions] = useState<SubmissionManifest[]>([]);
-	const [submissionId, setSubmissionId] = useState<string>('');
 	const [uploadError, setUploadError] = useState<BatchError[]>([]);
 	const [validationState, validationDispatch] = useReducer(validationReducer, validationParameters);
 	const { oneCsv, oneOrMoreTar } = validationState;
 	const thereAreFiles = hasFiles(validationState);
-	const [openGuideModal, setOpenGuideModal] = useState(false);
 	const [previousSubmission, setPreviousSubmission] = useState<SubmissionSummary | undefined>(undefined);
 
 	const { awaitingResponse, submitData, downloadMetadataTemplateUrl, fetchPreviousSubmissions } =
@@ -125,7 +120,6 @@ const NewSubmissions = (): ReactElement => {
 	});
 	const hasBlockingIssues = hasSubmissionBlockingIssues({
 		uploadError,
-		filesSubmissionInstructions,
 		isCsvRequiredButMissing: isCsvRequiredButMissingForSubmission,
 	});
 	const enableSubmitButton = shouldEnableSubmitButton({
@@ -196,19 +190,11 @@ const NewSubmissions = (): ReactElement => {
 				}
 
 				case CreateSubmissionStatus.PROCESSING: {
-					if (response.submissionId && oneOrMoreTar.length === 0) {
+					if (response.submissionId) {
 						Router.push(
 							getInternalLink({
 								path: urlJoin('submission', 'environmental', response.submissionId.toString()),
 							}),
-						);
-					} else if (response.submissionId && oneOrMoreTar.length > 0) {
-						setFilesSubmissionInstructions(response.submissionManifest);
-						setSubmissionId(response.submissionId.toString());
-						setOpenGuideModal(
-							response.submissionManifest &&
-								response.submissionManifest.length > 0 &&
-								response.submissionId != null,
 						);
 					} else {
 						console.log('Unhandled response:', response);
@@ -563,23 +549,6 @@ const NewSubmissions = (): ReactElement => {
 						</tr>
 					</tfoot>
 				</table>
-				{openGuideModal && (
-					<FileUploadInstructionsModal
-						submissionManifest={filesSubmissionInstructions}
-						submissionId={submissionId}
-						onClose={() => {
-							setOpenGuideModal(false);
-							setFilesSubmissionInstructions([]);
-							setSubmissionId('');
-							validationDispatch({ type: 'clear all' });
-							Router.push(
-								getInternalLink({
-									path: urlJoin('submission', 'environmental', submissionId),
-								}),
-							);
-						}}
-					/>
-				)}
 				{confirmSubmissionModalOpen && (
 					<ConfirmSubmissionModal
 						onClose={() => setConfirmSubmissionModalOpen(false)}

--- a/components/pages/submission/Environmental/NewSubmissions/validationHelpers.ts
+++ b/components/pages/submission/Environmental/NewSubmissions/validationHelpers.ts
@@ -22,7 +22,6 @@
 import { Dispatch } from 'react';
 
 import type { SubmissionSummary } from '#global/hooks/useEnvironmentalData';
-import type { SubmissionManifest } from '#global/utils/fileManifest';
 
 import {
 	acceptedFileExtensions,

--- a/components/pages/submission/Environmental/NewSubmissions/validationHelpers.ts
+++ b/components/pages/submission/Environmental/NewSubmissions/validationHelpers.ts
@@ -189,14 +189,12 @@ export const isCsvRequiredButMissing = ({
 // Returns true if there are submission blocking issues
 export const hasSubmissionBlockingIssues = ({
 	uploadError,
-	filesSubmissionInstructions,
 	isCsvRequiredButMissing,
 }: {
 	uploadError: BatchError[];
-	filesSubmissionInstructions: SubmissionManifest[];
 	isCsvRequiredButMissing: boolean;
 }) => {
-	return uploadError.length > 0 || filesSubmissionInstructions.length > 0 || isCsvRequiredButMissing;
+	return uploadError.length > 0 || isCsvRequiredButMissing;
 };
 
 // This function returns true when the "Submit" button should be enabled.

--- a/global/hooks/useEnvironmentalData/index.ts
+++ b/global/hooks/useEnvironmentalData/index.ts
@@ -30,8 +30,8 @@ import useAuthContext from '#global/hooks/useAuthContext';
 import processStream from '#global/utils/processStream';
 
 import {
+	type CommitSubmissionResponse,
 	SubmissionStatus,
-	type CommitSubmissionResult,
 	type ErrorDetails,
 	type RecordValidationErrorDetails,
 	type SubmissionFile,
@@ -108,7 +108,7 @@ const useEnvironmentalData = (origin: string) => {
 	const commitSubmission = async (
 		id: string,
 		{ signal }: { signal?: AbortSignal } = {},
-	): Promise<CommitSubmissionResult> => {
+	): Promise<CommitSubmissionResponse> => {
 		return handleRequest({
 			url: urlJoin(
 				NEXT_PUBLIC_ENVIRONMENTAL_SUBMISSION_API_URL,

--- a/global/hooks/useEnvironmentalData/types.ts
+++ b/global/hooks/useEnvironmentalData/types.ts
@@ -125,6 +125,13 @@ export type CommitSubmissionResult = {
 	processedEntities: string[];
 };
 
+export type CommitSubmissionErrorResult = {
+	error: string;
+	message: string;
+};
+
+export type CommitSubmissionResponse = CommitSubmissionResult | CommitSubmissionErrorResult;
+
 export type SubmissionFile = {
 	fileName: string;
 	isUploaded: boolean;


### PR DESCRIPTION
# Description
This PR removes automatic submission commits and introduces a manual confirmation step. Users now explicitly confirm when a submission is complete.

## Details
- Replaces automatic commit behaviour with a new `"Confirm Submission"` button on the Submission Details page, requires the user to click the button to confirm the submission is complete.
- The "Confirm Submission" button is enabled only when Data Validation is **VALID** and there are no pending upload files.

## Screenshot

<img width="1535" height="408" alt="image" src="https://github.com/user-attachments/assets/78136863-37b8-4642-b826-5d2f7e2e51d0" />

**(green button "Confirm Submission" is displayed on top right corner of the table)**
